### PR TITLE
Added update script. Update to latest build.

### DIFF
--- a/get_patch.py
+++ b/get_patch.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+
+"""
+DON'T RUN THIS FILE
+- it's only here for reference sake in terms of how I made the patch file.
+RUN ./update.py INSTEAD
+"""
+
+import sys
+sys.path.append("../pa_tools")
+
+
+import loader
+from collections import OrderedDict
+import patcher
+import utils
+import os
+
+# get base pa directory
+base_path = utils.pa_media_dir()
+# the directory where the mod files are (right here in this case xD)
+mod_path = '.'
+
+# get the unit list file dir
+unit_list_path = os.path.join(base_path, "pa/units/unit_list.json")
+
+# unit list files for comparing
+unit_list = loader.load(unit_list_path)
+
+patches = []
+
+# iterate over all the units
+for unit_file in unit_list['units']:
+    # get rid of the extra slash at the start so that path join works
+    unit_file = unit_file[1:]
+    base_unit_path = os.path.join(base_path, unit_file)
+
+    unit_base = loader.load(base_unit_path)
+
+    # check to see if it's actually a file we've bothered shadowing or not:
+    mod_unit_path = os.path.join(mod_path, unit_file)
+
+    # the mod doesn't shadow this file; no need to compare them
+    if not os.path.exists(mod_unit_path): continue
+
+    unit_mod = loader.load(mod_unit_path)
+
+    # compute diff in terms of json diff
+    diff = patcher.from_diff(unit_base, unit_mod)
+
+    # remove anything that isn't to do with fx_offsets (since those changes represent balance/configuration changes)
+
+    diff = [op for op in diff if op['path'].startswith('/fx_offsets')]
+
+    os.remove(mod_unit_path)
+
+    for op in diff:
+        # here just to make things robust, we use the more generic version of 'add' to array
+        if op['path'].startswith('/fx_offsets/'):
+            # this path just means append to the end of the array
+            # which means we are not relying on the number of fx that are already on a unit in PA's base game files
+            # this makes the patch itself more robust
+            op['path'] = '/fx_offsets/-'
+
+    # store this patch
+    patches.append(OrderedDict([('target', unit_file),('patch', diff )]))
+
+options = loader.loads("""{
+            "output_dir" : ".",
+            "pretty_print_effects" : true,
+            "indent" : 2
+        }""")
+
+modinfo = loader.loads("""{
+  "context": "client",
+  "identifier": "com.uberent.pa.PAFX",
+  "display_name": "PA-FX",
+  "description": "Adding more effects to Buildings & Units",
+  "author": "Alpha2546, Fr33Lancer",
+  "version": "2.5",
+  "signature": "not yet implemented",
+  "forum": "https://forums.uberent.com/threads/rel-pa-fx-moar-effects-in-pa-75499.66155/",
+  "icon": "https://i.imgflip.com/ekl6p.gif",
+  "category": [
+      "in-game",
+      "shader",
+      "colours",
+      "particles",
+      "effects",
+      "buildings"
+    ],
+  "priority": 100
+}""")
+
+patcher_mod_file = OrderedDict([
+        ('options', options),
+        ('modinfo', modinfo),
+        ('mod', patches)
+    ])
+
+# now store all these patches in a single file
+loader.dump(patcher_mod_file, 'pa_fx_gen.json', indent=2)
+
+
+
+
+
+
+
+
+

--- a/modinfo.json
+++ b/modinfo.json
@@ -1,22 +1,22 @@
 {
-  "context": "client",
-  "identifier": "com.uberent.pa.PAFX",
-  "display_name": "PA-FX",
-  "description": "Adding more effects to Buildings & Units",
-  "author": "Alpha2546, Fr33Lancer",
-  "version": "2.5",
-  "build": "78071",
-  "date": "2015/02/12",
-  "signature": "not yet implemented",
-  "forum": "https://forums.uberent.com/threads/rel-pa-fx-moar-effects-in-pa-75499.66155/",
-  "icon": "https://i.imgflip.com/ekl6p.gif",
-  "category": [
-	  "in-game",
-	  "shader",
-	  "colours",
-	  "particles",
-	  "effects",
-	  "buildings"
+    "context": "client",
+    "identifier": "com.uberent.pa.PAFX",
+    "display_name": "PA-FX",
+    "description": "Adding more effects to Buildings & Units",
+    "author": "Alpha2546, Fr33Lancer",
+    "version": "2.5",
+    "signature": "not yet implemented",
+    "forum": "https://forums.uberent.com/threads/rel-pa-fx-moar-effects-in-pa-75499.66155/",
+    "icon": "https://i.imgflip.com/ekl6p.gif",
+    "category": [
+        "in-game",
+        "shader",
+        "colours",
+        "particles",
+        "effects",
+        "buildings"
     ],
-  "priority": 100
+    "priority": 100,
+    "build": "83796",
+    "date": "2015/07/16"
 }

--- a/pa/units/air/air_factory/air_factory.json
+++ b/pa/units/air/air_factory/air_factory.json
@@ -1,326 +1,1460 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:air_factory.message):Air Factory",
-	"description": "!LOC(units:basic_manufacturing_builds_air_units.message):Basic manufacturing- Builds air units.",
-	"max_health": 6000,
-	"build_metal_cost": 720,
-	"atrophy_rate": 12.0,
-	"atrophy_cool_down": 15.0,
-	"spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
-	"buildable_types": "(Air & Mobile & Basic | Air & Fabber & Basic & Mobile) & FactoryBuild",
-	"rolloff_dirs": [[1,
-	0,
-	0],
-	[-1,
-	0,
-	0],
-	[0,
-	1,
-	0],
-	[0,
-	-1,
-	0]],
-	"wait_to_rolloff_time": 0,
-	"factory_cooldown_time": 2,
-	"unit_types": ["UNITTYPE_Factory",
-	"UNITTYPE_Construction",
-	"UNITTYPE_Air",
-	"UNITTYPE_Structure",
-	"UNITTYPE_Basic",
-	"UNITTYPE_CmdBuild",
-	"UNITTYPE_FabBuild",
-	"UNITTYPE_FabAdvBuild",
-	"UNITTYPE_Important"],
-	"command_caps": ["ORDER_Move",
-	"ORDER_Patrol",
-	"ORDER_FactoryBuild",
-	"ORDER_Reclaim",
-	"ORDER_Repair",
-	"ORDER_Attack",
-	"ORDER_Assist"],
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			}]
-		}
-	},
-	"model": [{
-		"layer": "WL_LandHorizontal",
-		"filename": "/pa/units/air/air_factory/air_factory.papa",
-		"animations": {
-			"build_start": "/pa/units/air/air_factory/air_factory_anim_start.papa",
-			"build_loop": "/pa/units/air/air_factory/air_factory_anim_build.papa",
-			"build_end": "/pa/units/air/air_factory/air_factory_anim_end.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/factory_anim_tree.json",
-		"skirt_decal": "/pa/effects/specs/skirt_air.json"
-	},
-	{
-		"layer": "WL_WaterSurface",
-		"filename": "/pa/units/sea/air_factory/air_factory.papa",
-		"animations": {
-			"build_start": "/pa/units/air/air_factory/air_factory_anim_start.papa",
-			"build_loop": "/pa/units/air/air_factory/air_factory_anim_build.papa",
-			"build_end": "/pa/units/air/air_factory/air_factory_anim_end.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/factory_anim_tree.json"
-	}],
-	"tools": [{
-		"spec_id": "/pa/units/air/air_factory/air_factory_build_arm.json",
-		"aim_bone": "bone_root"
-	}],
-	"events": {
-		"died": {
-			"effect_scale": 1.0
-		}
-	},
-	"audio": {
-		"loops": {
-			"build": {
-				"cue": "/SE/Construction/Factory_contruction_loop_air",
-				"flag": "build_target_changed",
-				"should_start_func": "has_build_target",
-				"should_stop_func": "no_build_target"
-			}
-		}
-	},
-	"fx_offsets": [{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "bone_outsideRing",
-		"offset": [-6.45,
-		6.45,
-		0],
-		"orientation": [0,
-		0,
-		-45]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "bone_outsideRing",
-		"offset": [6.45,
-		6.45,
-		0],
-		"orientation": [0,
-		0,
-		45]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "bone_outsideRing",
-		"offset": [6.45,
-		-6.45,
-		0],
-		"orientation": [0,
-		0,
-		135]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "bone_outsideRing",
-		"offset": [-6.45,
-		-6.45,
-		0],
-		"orientation": [0,
-		0,
-		-135]
-	}, {
-			"type" : "build",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/air/air_factory/light_build.pfx",
-			"offset" : [0, 0, 0]
-		}, {
-			"type" : "build",
-			"bone" : "bone_outsideRing",
-			"filename" : "/pa/units/air/air_factory/light_build_bone_2.pfx",
-			"offset" : [0, 9.4, 0]
-		}, {
-			"type" : "build",
-			"bone" : "bone_outsideRing",
-			"filename" : "/pa/units/air/air_factory/light_build_bone_2_2.pfx",
-			"offset" : [0, -9.4, 0]
-		}, {
-			"type" : "build",
-			"bone" : "bone_outsideRing",
-			"filename" : "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
-			"offset" : [7.25, -7.25, 0]
-		}, {
-			"type" : "build",
-			"bone" : "bone_outsideRing",
-			"filename" : "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
-			"offset" : [-7.25, -7.25, 0]
-		}, {
-			"type" : "build",
-			"bone" : "bone_outsideRing",
-			"filename" : "/pa/units/air/air_factory/light_build_bone_4.pfx",
-			"offset" : [7.25, 7.25, 0]
-		}, {
-			"type" : "build",
-			"bone" : "bone_outsideRing",
-			"filename" : "/pa/units/air/air_factory/light_build_bone_4.pfx",
-			"offset" : [-7.25, 7.25, 0]
-		}, {
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/air/air_factory/dot_1.pfx",
-			"offset" : [0, 0, 0]
-		}, {
-			"type" : "idle",
-			"bone" : "bone_outsideRing",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset" : [0, 9.4, 0]
-		}, {
-			"type" : "idle",
-			"bone" : "bone_outsideRing",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset" : [0, -9.4, 0]
-		}, {
-			"type" : "idle",
-			"bone" : "bone_outsideRing",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset" : [7.25, -7.25, 0]
-		}, {
-			"type" : "idle",
-			"bone" : "bone_outsideRing",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset" : [-7.25, -7.25, 0]
-		}, {
-			"type" : "idle",
-			"bone" : "bone_outsideRing",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset" : [7.25, 7.25, 0]
-		}, {
-			"type" : "idle",
-			"bone" : "bone_outsideRing",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset" : [-7.25, 7.25, 0]
-		}],
-	"headlights": [{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [5.67,
-		5.67,
-		2.5],
-		"orientation": [-35.0,
-		31.0,
-		0.0],
-		"near_width": 2.4,
-		"near_height": 2.4,
-		"near_distance": 1.0,
-		"far_distance": 15.0,
-		"color": [1.5,
-		1.52,
-		1.6],
-		"intensity": 3.0,
-		"bone": "bone_platform"
-	},
-	{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [5.67,
-		-5.67,
-		2.5],
-		"orientation": [-35.0,
-		-31.0,
-		0.0],
-		"near_width": 2.4,
-		"near_height": 2.4,
-		"near_distance": 1.0,
-		"far_distance": 15.0,
-		"color": [1.5,
-		1.52,
-		1.6],
-		"intensity": 3.0,
-		"bone": "bone_platform"
-	},
-	{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [-5.67,
-		5.67,
-		2.5],
-		"orientation": [35.0,
-		31.0,
-		0.0],
-		"near_width": 2.4,
-		"near_height": 2.4,
-		"near_distance": 1.0,
-		"far_distance": 15.0,
-		"color": [1.5,
-		1.52,
-		1.6],
-		"intensity": 3.0,
-		"bone": "bone_platform"
-	},
-	{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [-5.67,
-		-5.67,
-		2.5],
-		"orientation": [35.0,
-		-31.0,
-		0.0],
-		"near_width": 2.4,
-		"near_height": 2.4,
-		"near_distance": 1.0,
-		"far_distance": 15.0,
-		"color": [1.5,
-		1.52,
-		1.6],
-		"intensity": 3.0,
-		"bone": "bone_platform"
-	}],
-	"lamps": [{
-		"offset": [4.0,
-		-11.1,
-		6.0],
-		"radius": 8.0,
-		"color": [0.1,
-		1.0,
-		0.1],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-4.0,
-		-11.1,
-		6.0],
-		"radius": 8.0,
-		"color": [0.1,
-		1.0,
-		0.1],
-		"intensity": 2.0
-	},
-	{
-		"offset": [5.0,
-		14.12,
-		4.54],
-		"radius": 4.0,
-		"color": [1.0,
-		0.0,
-		0.0],
-		"intensity": 2.0
-	}],
-	"death": {
-		"decals": ["/pa/effects/specs/scorch_c_01.json"]
-	},
-	"mesh_bounds": [30,
-	30,
-	15],
-	"placement_size": [30,
-	30],
-	"area_build_separation": 3,
-	"TEMP_texelinfo": 37.6046,
-	"physics": {
-		"collision_layers": "WL_AnyHorizontalGroundOrWaterSurface"
-	}
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:air_factory.message):Air Factory",
+  "description": "!LOC(units:basic_manufacturing_builds_air_units.message):Basic manufacturing- Builds air units.",
+  "max_health": 6000,
+  "build_metal_cost": 720,
+  "atrophy_rate": 12.0,
+  "atrophy_cool_down": 15.0,
+  "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
+  "buildable_types": "(Air & Mobile & Basic | Air & Fabber & Basic & Mobile) & FactoryBuild",
+  "rolloff_dirs": [
+    [
+      1,
+      0,
+      0
+    ],
+    [
+      -1,
+      0,
+      0
+    ],
+    [
+      0,
+      1,
+      0
+    ],
+    [
+      0,
+      -1,
+      0
+    ]
+  ],
+  "wait_to_rolloff_time": 0,
+  "factory_cooldown_time": 2,
+  "unit_types": [
+    "UNITTYPE_Factory",
+    "UNITTYPE_Construction",
+    "UNITTYPE_Air",
+    "UNITTYPE_Structure",
+    "UNITTYPE_Basic",
+    "UNITTYPE_CmdBuild",
+    "UNITTYPE_FabBuild",
+    "UNITTYPE_FabAdvBuild",
+    "UNITTYPE_Important"
+  ],
+  "command_caps": [
+    "ORDER_Move",
+    "ORDER_Patrol",
+    "ORDER_FactoryBuild",
+    "ORDER_Reclaim",
+    "ORDER_Repair",
+    "ORDER_Attack",
+    "ORDER_Assist"
+  ],
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        }
+      ]
+    }
+  },
+  "model": [
+    {
+      "layer": "WL_LandHorizontal",
+      "filename": "/pa/units/air/air_factory/air_factory.papa",
+      "animations": {
+        "build_start": "/pa/units/air/air_factory/air_factory_anim_start.papa",
+        "build_loop": "/pa/units/air/air_factory/air_factory_anim_build.papa",
+        "build_end": "/pa/units/air/air_factory/air_factory_anim_end.papa"
+      },
+      "animtree": "/pa/anim/anim_trees/factory_anim_tree.json",
+      "skirt_decal": "/pa/effects/specs/skirt_air.json"
+    },
+    {
+      "layer": "WL_WaterSurface",
+      "filename": "/pa/units/sea/air_factory/air_factory.papa",
+      "animations": {
+        "build_start": "/pa/units/air/air_factory/air_factory_anim_start.papa",
+        "build_loop": "/pa/units/air/air_factory/air_factory_anim_build.papa",
+        "build_end": "/pa/units/air/air_factory/air_factory_anim_end.papa"
+      },
+      "animtree": "/pa/anim/anim_trees/factory_anim_tree.json"
+    }
+  ],
+  "tools": [
+    {
+      "spec_id": "/pa/units/air/air_factory/air_factory_build_arm.json",
+      "aim_bone": "bone_root"
+    }
+  ],
+  "events": {
+    "died": {
+      "effect_scale": 1.0
+    }
+  },
+  "audio": {
+    "loops": {
+      "build": {
+        "cue": "/SE/Construction/Factory_contruction_loop_air",
+        "flag": "build_target_changed",
+        "should_start_func": "has_build_target",
+        "should_stop_func": "no_build_target"
+      }
+    }
+  },
+  "fx_offsets": [
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "bone_outsideRing",
+      "offset": [
+        -6.45,
+        6.45,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        -45
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "bone_outsideRing",
+      "offset": [
+        6.45,
+        6.45,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        45
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "bone_outsideRing",
+      "offset": [
+        6.45,
+        -6.45,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        135
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "bone_outsideRing",
+      "offset": [
+        -6.45,
+        -6.45,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        -135
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory/light_build.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        9.4,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_2_2.pfx",
+      "offset": [
+        0,
+        -9.4,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
+      "offset": [
+        7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
+      "offset": [
+        -7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4.pfx",
+      "offset": [
+        7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4.pfx",
+      "offset": [
+        -7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory/dot_1.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        9.4,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        -9.4,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        -9.4,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        9.4,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory/dot_1.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4.pfx",
+      "offset": [
+        -7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4.pfx",
+      "offset": [
+        7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
+      "offset": [
+        -7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
+      "offset": [
+        7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_2_2.pfx",
+      "offset": [
+        0,
+        -9.4,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        9.4,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory/light_build.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory/light_build.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        9.4,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_2_2.pfx",
+      "offset": [
+        0,
+        -9.4,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
+      "offset": [
+        7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
+      "offset": [
+        -7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4.pfx",
+      "offset": [
+        7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4.pfx",
+      "offset": [
+        -7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory/dot_1.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        9.4,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        -9.4,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        -9.4,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        9.4,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory/dot_1.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4.pfx",
+      "offset": [
+        -7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4.pfx",
+      "offset": [
+        7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
+      "offset": [
+        -7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
+      "offset": [
+        7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_2_2.pfx",
+      "offset": [
+        0,
+        -9.4,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        9.4,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory/light_build.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory/light_build.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        9.4,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_2_2.pfx",
+      "offset": [
+        0,
+        -9.4,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
+      "offset": [
+        7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
+      "offset": [
+        -7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4.pfx",
+      "offset": [
+        7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4.pfx",
+      "offset": [
+        -7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory/dot_1.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        9.4,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        -9.4,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        -9.4,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        9.4,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory/dot_1.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4.pfx",
+      "offset": [
+        -7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4.pfx",
+      "offset": [
+        7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
+      "offset": [
+        -7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
+      "offset": [
+        7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_2_2.pfx",
+      "offset": [
+        0,
+        -9.4,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        9.4,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory/light_build.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory/light_build.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        9.4,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_2_2.pfx",
+      "offset": [
+        0,
+        -9.4,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
+      "offset": [
+        7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
+      "offset": [
+        -7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4.pfx",
+      "offset": [
+        7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4.pfx",
+      "offset": [
+        -7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory/dot_1.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        9.4,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        -9.4,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        -9.4,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        9.4,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory/dot_1.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4.pfx",
+      "offset": [
+        -7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4.pfx",
+      "offset": [
+        7.25,
+        7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
+      "offset": [
+        -7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
+      "offset": [
+        7.25,
+        -7.25,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_2_2.pfx",
+      "offset": [
+        0,
+        -9.4,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_outsideRing",
+      "filename": "/pa/units/air/air_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        9.4,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory/light_build.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    }
+  ],
+  "headlights": [
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        5.67,
+        5.67,
+        2.5
+      ],
+      "orientation": [
+        -35.0,
+        31.0,
+        0.0
+      ],
+      "near_width": 2.4,
+      "near_height": 2.4,
+      "near_distance": 1.0,
+      "far_distance": 15.0,
+      "color": [
+        1.5,
+        1.52,
+        1.6
+      ],
+      "intensity": 3.0,
+      "bone": "bone_platform"
+    },
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        5.67,
+        -5.67,
+        2.5
+      ],
+      "orientation": [
+        -35.0,
+        -31.0,
+        0.0
+      ],
+      "near_width": 2.4,
+      "near_height": 2.4,
+      "near_distance": 1.0,
+      "far_distance": 15.0,
+      "color": [
+        1.5,
+        1.52,
+        1.6
+      ],
+      "intensity": 3.0,
+      "bone": "bone_platform"
+    },
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        -5.67,
+        5.67,
+        2.5
+      ],
+      "orientation": [
+        35.0,
+        31.0,
+        0.0
+      ],
+      "near_width": 2.4,
+      "near_height": 2.4,
+      "near_distance": 1.0,
+      "far_distance": 15.0,
+      "color": [
+        1.5,
+        1.52,
+        1.6
+      ],
+      "intensity": 3.0,
+      "bone": "bone_platform"
+    },
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        -5.67,
+        -5.67,
+        2.5
+      ],
+      "orientation": [
+        35.0,
+        -31.0,
+        0.0
+      ],
+      "near_width": 2.4,
+      "near_height": 2.4,
+      "near_distance": 1.0,
+      "far_distance": 15.0,
+      "color": [
+        1.5,
+        1.52,
+        1.6
+      ],
+      "intensity": 3.0,
+      "bone": "bone_platform"
+    }
+  ],
+  "lamps": [
+    {
+      "offset": [
+        4.0,
+        -11.1,
+        6.0
+      ],
+      "radius": 8.0,
+      "color": [
+        0.1,
+        1.0,
+        0.1
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -4.0,
+        -11.1,
+        6.0
+      ],
+      "radius": 8.0,
+      "color": [
+        0.1,
+        1.0,
+        0.1
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        5.0,
+        14.12,
+        4.54
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "intensity": 2.0
+    }
+  ],
+  "death": {
+    "decals": [
+      "/pa/effects/specs/scorch_c_01.json"
+    ]
+  },
+  "mesh_bounds": [
+    30,
+    30,
+    15
+  ],
+  "placement_size": [
+    40,
+    40
+  ],
+  "area_build_separation": 2,
+  "TEMP_texelinfo": 37.6046,
+  "physics": {
+    "collision_layers": "WL_AnyHorizontalGroundOrWaterSurface"
+  }
 }

--- a/pa/units/air/air_factory_adv/air_factory_adv.json
+++ b/pa/units/air/air_factory_adv/air_factory_adv.json
@@ -1,414 +1,2166 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:advanced_air_factory.message):Advanced Air Factory",
-	"description": "!LOC(units:advanced_manufacturing_builds_air_units.message):Advanced manufacturing- Builds air units.",
-	"max_health": 30000,
-	"build_metal_cost": 4800,
-	"atrophy_rate": 80.0,
-	"atrophy_cool_down": 15.0,
-	"buildable_types": "Air & Mobile & FactoryBuild",
-	"rolloff_dirs": [[1,
-	0,
-	0],
-	[-1,
-	0,
-	0],
-	[0,
-	1,
-	0],
-	[0,
-	-1,
-	0]],
-	"spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
-	"wait_to_rolloff_time": 0,
-	"factory_cooldown_time": 2,
-	"unit_types": ["UNITTYPE_Factory",
-	"UNITTYPE_Construction",
-	"UNITTYPE_Air",
-	"UNITTYPE_Structure",
-	"UNITTYPE_Advanced",
-	"UNITTYPE_Important"],
-	"command_caps": ["ORDER_Move",
-	"ORDER_Patrol",
-	"ORDER_FactoryBuild",
-	"ORDER_Reclaim",
-	"ORDER_Repair",
-	"ORDER_Attack",
-	"ORDER_Assist"],
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			}]
-		}
-	},
-	"model": [{
-		"layer": "WL_LandHorizontal",
-		"filename": "/pa/units/air/air_factory_adv/air_factory_adv.papa",
-		"animations": {
-			"build_start": "/pa/units/air/air_factory_adv/air_factory_adv_anim_start.papa",
-			"build_loop": "/pa/units/air/air_factory_adv/air_factory_adv_anim_build.papa",
-			"build_end": "/pa/units/air/air_factory_adv/air_factory_adv_anim_end.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/factory_anim_tree.json",
-		"skirt_decal": "/pa/effects/specs/skirt_air_adv.json"
-	},
-	{
-		"layer": "WL_WaterSurface",
-		"filename": "/pa/units/sea/air_factory_adv/air_factory_adv.papa",
-		"animations": {
-			"build_start": "/pa/units/air/air_factory_adv/air_factory_adv_anim_start.papa",
-			"build_loop": "/pa/units/air/air_factory_adv/air_factory_adv_anim_build.papa",
-			"build_end": "/pa/units/air/air_factory_adv/air_factory_adv_anim_end.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/factory_anim_tree.json"
-	}],
-	"tools": [{
-		"spec_id": "/pa/units/air/air_factory_adv/air_factory_adv_build_arm.json",
-		"aim_bone": "bone_root"
-	}],
-	"events": {
-		"died": {
-			"effect_scale": 2.0
-		}
-	},
-	"audio": {
-		"loops": {
-			"build": {
-				"cue": "/SE/Construction/Factory_contruction_loop_air",
-				"flag": "build_target_changed",
-				"should_start_func": "has_build_target",
-				"should_stop_func": "no_build_target"
-			}
-		}
-	},
-	"fx_offsets": [{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_nozzle01",
-		"offset": [0,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_nozzle02",
-		"offset": [0,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_nozzle03",
-		"offset": [0,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_nozzle04",
-		"offset": [0,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_nozzle05",
-		"offset": [0,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_nozzle06",
-		"offset": [0,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_nozzle07",
-		"offset": [0,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_nozzle08",
-		"offset": [0,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	}, {
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/air/air_factory_adv/dot_1.pfx",
-			"offset" : [0, 0, 0]
-		}, {
-			"type" : "build",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/air/air_factory_adv/light_build.pfx",
-			"offset" : [0, 0, 0]
-		},  {
-			"type" : "build",
-			"bone": "socket_nozzle01",
-			"filename" : "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
-			"offset" : [0, 1.45, 0]
-		}, {
-			"type" : "build",
-			"bone": "socket_nozzle02",
-			"filename" : "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
-			"offset" : [0, 1.45, 0]
-		}, {
-			"type" : "build",
-			"bone": "socket_nozzle03",
-			"filename" : "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
-			"offset" : [0, 1.45, 0]
-		}, {
-			"type" : "build",
-			"bone": "socket_nozzle04",
-			"filename" : "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
-			"offset" : [0, 1.45, 0]
-		}, {
-			"type" : "build",
-			"bone": "socket_nozzle05",
-			"filename" : "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
-			"offset" : [0, 1.45, 0]
-		}, {
-			"type" : "build",
-			"bone": "socket_nozzle06",
-			"filename" : "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
-			"offset" : [0, 1.45, 0]
-		}, {
-			"type" : "build",
-			"bone": "socket_nozzle07",
-			"filename" : "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
-			"offset" : [0, 1.45, 0]
-		}, {
-			"type" : "build",
-			"bone": "socket_nozzle08",
-			"filename" : "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
-			"offset" : [0, 1.45, 0]
-		}, {
-			"type" : "build",
-			"bone": "socket_nozzle08",
-			"filename" : "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
-			"offset" : [-12.3, -5, 0]
-		}, {
-			"type" : "build",
-			"bone": "socket_nozzle05",
-			"filename" : "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
-			"offset" : [12.3, -5, 0]
-		},  {
-			"type" : "idle",
-			"bone": "socket_nozzle01",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset" : [0, 1.45, 0]
-		}, {
-			"type" : "idle",
-			"bone": "socket_nozzle02",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset" : [0, 1.45, 0]
-		}, {
-			"type" : "idle",
-			"bone": "socket_nozzle03",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset" : [0, 1.45, 0]
-		}, {
-			"type" : "idle",
-			"bone": "socket_nozzle04",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset" : [0, 1.45, 0]
-		}, {
-			"type" : "idle",
-			"bone": "socket_nozzle05",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset" : [0, 1.45, 0]
-		}, {
-			"type" : "idle",
-			"bone": "socket_nozzle06",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset" : [0, 1.45, 0]
-		}, {
-			"type" : "idle",
-			"bone": "socket_nozzle07",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset" : [0, 1.45, 0]
-		}, {
-			"type" : "idle",
-			"bone": "socket_nozzle08",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset" : [0, 1.45, 0]
-		}, {
-			"type" : "idle",
-			"bone": "socket_nozzle08",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset" : [-12.3, -5, 0]
-		}, {
-			"type" : "idle",
-			"bone": "socket_nozzle05",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset" : [12.3, -5, 0]
-		}],
-	"headlights": [{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [9.5,
-		9.5,
-		2.5],
-		"orientation": [-35.0,
-		31.0,
-		0.0],
-		"near_width": 3.0,
-		"near_height": 3.0,
-		"near_distance": 1.0,
-		"far_distance": 20.0,
-		"color": [1.5,
-		1.52,
-		1.6],
-		"intensity": 3.0,
-		"bone": "bone_platform"
-	},
-	{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [9.5,
-		-9.5,
-		2.5],
-		"orientation": [-35.0,
-		-31.0,
-		0.0],
-		"near_width": 3.0,
-		"near_height": 3.0,
-		"near_distance": 1.0,
-		"far_distance": 20.0,
-		"color": [1.5,
-		1.52,
-		1.6],
-		"intensity": 3.0,
-		"bone": "bone_platform"
-	},
-	{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [-9.5,
-		9.5,
-		2.5],
-		"orientation": [35.0,
-		31.0,
-		0.0],
-		"near_width": 3.0,
-		"near_height": 3.0,
-		"near_distance": 1.0,
-		"far_distance": 20.0,
-		"color": [1.5,
-		1.52,
-		1.6],
-		"intensity": 3.0,
-		"bone": "bone_platform"
-	},
-	{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [-9.5,
-		-9.5,
-		2.5],
-		"orientation": [35.0,
-		-31.0,
-		0.0],
-		"near_width": 3.0,
-		"near_height": 3.0,
-		"near_distance": 1.0,
-		"far_distance": 20.0,
-		"color": [1.5,
-		1.52,
-		1.6],
-		"intensity": 3.0,
-		"bone": "bone_platform"
-	}],
-	"lamps": [{
-		"offset": [8.02,
-		-20.88,
-		12.04],
-		"radius": 8.0,
-		"color": [0.1,
-		1.0,
-		0.1],
-		"intensity": 2.0
-	},
-	{
-		"offset": [0.0,
-		-20.88,
-		12.04],
-		"radius": 8.0,
-		"color": [0.1,
-		1.0,
-		0.1],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-8.02,
-		-20.88,
-		12.04],
-		"radius": 8.0,
-		"color": [0.1,
-		1.0,
-		0.1],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-4.0,
-		-23.79,
-		8.44],
-		"radius": 4.0,
-		"color": [1.0,
-		0.0,
-		0.0],
-		"intensity": 2.0
-	}],
-	"mesh_bounds": [50,
-	50,
-	25],
-	"placement_size": [50,
-	50],
-	"area_build_separation": 7,
-	"TEMP_texelinfo": 65.6074,
-	"physics": {
-		"collision_layers": "WL_AnyHorizontalGroundOrWaterSurface"
-	}
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:advanced_air_factory.message):Advanced Air Factory",
+  "description": "!LOC(units:advanced_manufacturing_builds_air_units.message):Advanced manufacturing- Builds air units.",
+  "max_health": 30000,
+  "build_metal_cost": 4800,
+  "atrophy_rate": 80.0,
+  "atrophy_cool_down": 15.0,
+  "buildable_types": "Air & Mobile & FactoryBuild",
+  "rolloff_dirs": [
+    [
+      1,
+      0,
+      0
+    ],
+    [
+      -1,
+      0,
+      0
+    ],
+    [
+      0,
+      1,
+      0
+    ],
+    [
+      0,
+      -1,
+      0
+    ]
+  ],
+  "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
+  "wait_to_rolloff_time": 0,
+  "factory_cooldown_time": 2,
+  "unit_types": [
+    "UNITTYPE_Factory",
+    "UNITTYPE_Construction",
+    "UNITTYPE_Air",
+    "UNITTYPE_Structure",
+    "UNITTYPE_Advanced",
+    "UNITTYPE_Important"
+  ],
+  "command_caps": [
+    "ORDER_Move",
+    "ORDER_Patrol",
+    "ORDER_FactoryBuild",
+    "ORDER_Reclaim",
+    "ORDER_Repair",
+    "ORDER_Attack",
+    "ORDER_Assist"
+  ],
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        }
+      ]
+    }
+  },
+  "model": [
+    {
+      "layer": "WL_LandHorizontal",
+      "filename": "/pa/units/air/air_factory_adv/air_factory_adv.papa",
+      "animations": {
+        "build_start": "/pa/units/air/air_factory_adv/air_factory_adv_anim_start.papa",
+        "build_loop": "/pa/units/air/air_factory_adv/air_factory_adv_anim_build.papa",
+        "build_end": "/pa/units/air/air_factory_adv/air_factory_adv_anim_end.papa"
+      },
+      "animtree": "/pa/anim/anim_trees/factory_anim_tree.json",
+      "skirt_decal": "/pa/effects/specs/skirt_air_adv.json"
+    },
+    {
+      "layer": "WL_WaterSurface",
+      "filename": "/pa/units/sea/air_factory_adv/air_factory_adv.papa",
+      "animations": {
+        "build_start": "/pa/units/air/air_factory_adv/air_factory_adv_anim_start.papa",
+        "build_loop": "/pa/units/air/air_factory_adv/air_factory_adv_anim_build.papa",
+        "build_end": "/pa/units/air/air_factory_adv/air_factory_adv_anim_end.papa"
+      },
+      "animtree": "/pa/anim/anim_trees/factory_anim_tree.json"
+    }
+  ],
+  "tools": [
+    {
+      "spec_id": "/pa/units/air/air_factory_adv/air_factory_adv_build_arm.json",
+      "aim_bone": "bone_root"
+    }
+  ],
+  "events": {
+    "died": {
+      "effect_scale": 2.0
+    }
+  },
+  "audio": {
+    "loops": {
+      "build": {
+        "cue": "/SE/Construction/Factory_contruction_loop_air",
+        "flag": "build_target_changed",
+        "should_start_func": "has_build_target",
+        "should_stop_func": "no_build_target"
+      }
+    }
+  },
+  "fx_offsets": [
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_nozzle01",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_nozzle02",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_nozzle03",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_nozzle04",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_nozzle05",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_nozzle06",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_nozzle07",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_nozzle08",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory_adv/dot_1.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory_adv/light_build.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle02",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle04",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle06",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        -12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle04",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle06",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle06",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle04",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        -12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle06",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle04",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle02",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory_adv/light_build.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory_adv/dot_1.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory_adv/dot_1.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory_adv/light_build.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle02",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle04",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle06",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        -12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle04",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle06",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle06",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle04",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        -12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle06",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle04",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle02",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory_adv/light_build.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory_adv/dot_1.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory_adv/dot_1.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory_adv/light_build.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle02",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle04",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle06",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        -12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle04",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle06",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle06",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle04",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        -12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle06",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle04",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle02",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory_adv/light_build.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory_adv/dot_1.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory_adv/dot_1.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory_adv/light_build.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle02",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle04",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle06",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        -12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle04",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle06",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle06",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle04",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        -12.3,
+        -5,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle08",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle06",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle04",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle02",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        0,
+        1.45,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory_adv/light_build.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/air/air_factory_adv/dot_1.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    }
+  ],
+  "headlights": [
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        9.5,
+        9.5,
+        2.5
+      ],
+      "orientation": [
+        -35.0,
+        31.0,
+        0.0
+      ],
+      "near_width": 3.0,
+      "near_height": 3.0,
+      "near_distance": 1.0,
+      "far_distance": 20.0,
+      "color": [
+        1.5,
+        1.52,
+        1.6
+      ],
+      "intensity": 3.0,
+      "bone": "bone_platform"
+    },
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        9.5,
+        -9.5,
+        2.5
+      ],
+      "orientation": [
+        -35.0,
+        -31.0,
+        0.0
+      ],
+      "near_width": 3.0,
+      "near_height": 3.0,
+      "near_distance": 1.0,
+      "far_distance": 20.0,
+      "color": [
+        1.5,
+        1.52,
+        1.6
+      ],
+      "intensity": 3.0,
+      "bone": "bone_platform"
+    },
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        -9.5,
+        9.5,
+        2.5
+      ],
+      "orientation": [
+        35.0,
+        31.0,
+        0.0
+      ],
+      "near_width": 3.0,
+      "near_height": 3.0,
+      "near_distance": 1.0,
+      "far_distance": 20.0,
+      "color": [
+        1.5,
+        1.52,
+        1.6
+      ],
+      "intensity": 3.0,
+      "bone": "bone_platform"
+    },
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        -9.5,
+        -9.5,
+        2.5
+      ],
+      "orientation": [
+        35.0,
+        -31.0,
+        0.0
+      ],
+      "near_width": 3.0,
+      "near_height": 3.0,
+      "near_distance": 1.0,
+      "far_distance": 20.0,
+      "color": [
+        1.5,
+        1.52,
+        1.6
+      ],
+      "intensity": 3.0,
+      "bone": "bone_platform"
+    }
+  ],
+  "lamps": [
+    {
+      "offset": [
+        8.02,
+        -20.88,
+        12.04
+      ],
+      "radius": 8.0,
+      "color": [
+        0.1,
+        1.0,
+        0.1
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        0.0,
+        -20.88,
+        12.04
+      ],
+      "radius": 8.0,
+      "color": [
+        0.1,
+        1.0,
+        0.1
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -8.02,
+        -20.88,
+        12.04
+      ],
+      "radius": 8.0,
+      "color": [
+        0.1,
+        1.0,
+        0.1
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -4.0,
+        -23.79,
+        8.44
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "intensity": 2.0
+    }
+  ],
+  "mesh_bounds": [
+    50,
+    50,
+    25
+  ],
+  "placement_size": [
+    60,
+    60
+  ],
+  "area_build_separation": 2,
+  "TEMP_texelinfo": 65.6074,
+  "physics": {
+    "collision_layers": "WL_AnyHorizontalGroundOrWaterSurface"
+  }
 }

--- a/pa/units/land/air_defense/air_defense.json
+++ b/pa/units/land/air_defense/air_defense.json
@@ -1,84 +1,109 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:galata_turret.message):Galata Turret",
-	"description": "!LOC(units:basic_turret_equipped_with_anti_air_missiles.message):Basic turret- Equipped with anti-air missiles.",
-	"max_health": 1000,
-	"build_metal_cost": 225,
-	"atrophy_rate": 5,
-	"atrophy_cool_down": 15,
-	"spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
-	"area_build_separation": 18,
-	"unit_types": ["UNITTYPE_Structure",
-	"UNITTYPE_Basic",
-	"UNITTYPE_Land",
-	"UNITTYPE_AirDefense",
-	"UNITTYPE_Defense",
-	"UNITTYPE_CmdBuild",
-	"UNITTYPE_FabBuild",
-	"UNITTYPE_FabAdvBuild",
-	"UNITTYPE_CombatFabAdvBuild"],
-	"command_caps": ["ORDER_Attack"],
-	"guard_layer": "WL_Air",
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 155
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 155
-			}]
-		}
-	},
-	"model": [{
-		"layer": "WL_LandHorizontal",
-		"filename": "/pa/units/land/air_defense/air_defense.papa",
-		"animtree": "/pa/anim/anim_trees/fabrication_turret_anim_tree.json",
-		"skirt_decal": "/pa/effects/specs/skirt_defense.json"
-	},
-	{
-		"layer": "WL_WaterSurface",
-		"filename": "/pa/units/sea/air_defense/air_defense.papa",
-		"animtree": "/pa/anim/anim_trees/fabrication_turret_anim_tree.json"
-	}],
-	"nearby_target_tick_update_interval": 2,
-	"tools": [{
-		"spec_id": "/pa/units/land/air_defense/air_defense_tool_weapon.json",
-		"aim_bone": "bone_pitch",
-		"muzzle_bone": ["socket_rightMuzzle",
-		"socket_leftMuzzle"]
-	}],
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/structure_small"
-		},
-		"fired": {
-			"audio_cue": "/SE/Weapons/structure/air_defense_fire",
-			"effect_spec": "/pa/effects/specs/default_muzzle_flash.pfx socket_rightMuzzle /pa/effects/specs/default_muzzle_flash.pfx socket_leftMuzzle"
-		},
-		"died": {
-			"audio_cue": "/SE/Death/structure_small",
-			"effect_scale": 0.5
-		}
-	},
-		"fx_offsets": [{
-		"type": "idle",
-		"bone": "socket_leftMuzzle",
-		"filename": "/pa/units/land/air_defense/aa_lights.pfx",
-		"offset" : [0, 0.75, 2.1]
-	}, {
-		"type" : "idle",
-		"bone" : "socket_rightMuzzle",
-		"filename": "/pa/units/land/air_defense/aa_lights.pfx",
-		"offset" : [0, 0.75, 2.1]
-		}],
-	"mesh_bounds": [5,
-	5,
-	9],
-	"TEMP_texelinfo": 9.4493
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:galata_turret.message):Galata Turret",
+  "description": "!LOC(units:basic_turret_equipped_with_anti_air_missiles.message):Basic turret- Equipped with anti-air missiles.",
+  "max_health": 1000,
+  "build_metal_cost": 225,
+  "atrophy_rate": 5,
+  "atrophy_cool_down": 15,
+  "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
+  "area_build_separation": 18,
+  "unit_types": [
+    "UNITTYPE_Structure",
+    "UNITTYPE_Basic",
+    "UNITTYPE_Land",
+    "UNITTYPE_AirDefense",
+    "UNITTYPE_Defense",
+    "UNITTYPE_CmdBuild",
+    "UNITTYPE_FabBuild",
+    "UNITTYPE_FabAdvBuild",
+    "UNITTYPE_CombatFabAdvBuild"
+  ],
+  "command_caps": [
+    "ORDER_Attack"
+  ],
+  "guard_layer": "WL_Air",
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 155
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 155
+        }
+      ]
+    }
+  },
+  "model": [
+    {
+      "layer": "WL_LandHorizontal",
+      "filename": "/pa/units/land/air_defense/air_defense.papa",
+      "animtree": "/pa/anim/anim_trees/fabrication_turret_anim_tree.json",
+      "skirt_decal": "/pa/effects/specs/skirt_defense.json"
+    },
+    {
+      "layer": "WL_WaterSurface",
+      "filename": "/pa/units/sea/air_defense/air_defense.papa",
+      "animtree": "/pa/anim/anim_trees/fabrication_turret_anim_tree.json"
+    }
+  ],
+  "nearby_target_tick_update_interval": 2,
+  "tools": [
+    {
+      "spec_id": "/pa/units/land/air_defense/air_defense_tool_weapon.json",
+      "aim_bone": "bone_pitch",
+      "muzzle_bone": [
+        "socket_rightMuzzle",
+        "socket_leftMuzzle"
+      ]
+    }
+  ],
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/structure_small"
+    },
+    "fired": {
+      "audio_cue": "/SE/Weapons/structure/air_defense_fire",
+      "effect_spec": "/pa/effects/specs/default_muzzle_flash.pfx socket_rightMuzzle /pa/effects/specs/default_muzzle_flash.pfx socket_leftMuzzle"
+    },
+    "died": {
+      "audio_cue": "/SE/Death/structure_small",
+      "effect_scale": 0.5
+    }
+  },
+  "mesh_bounds": [
+    5,
+    5,
+    9
+  ],
+  "TEMP_texelinfo": 9.4493,
+  "fx_offsets": [
+    {
+      "type": "idle",
+      "bone": "socket_leftMuzzle",
+      "filename": "/pa/units/land/air_defense/aa_lights.pfx",
+      "offset": [
+        0,
+        0.75,
+        2.1
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_rightMuzzle",
+      "filename": "/pa/units/land/air_defense/aa_lights.pfx",
+      "offset": [
+        0,
+        0.75,
+        2.1
+      ]
+    }
+  ]
 }

--- a/pa/units/land/air_defense_adv/air_defense_adv.json
+++ b/pa/units/land/air_defense_adv/air_defense_adv.json
@@ -1,83 +1,108 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:flak_cannon.message):Flak Cannon",
-	"description": "!LOC(units:advanced_turret_equipped_with_anti_air_turret.message):Advanced turret- Equipped with anti-air turret.",
-	"max_health": 2000,
-	"build_metal_cost": 900,
-	"atrophy_rate": 26.66667,
-	"atrophy_cool_down": 15,
-	"area_build_separation": 18,
-	"spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
-	"unit_types": ["UNITTYPE_Structure",
-	"UNITTYPE_Advanced",
-	"UNITTYPE_Land",
-	"UNITTYPE_AirDefense",
-	"UNITTYPE_Defense",
-	"UNITTYPE_FabAdvBuild"],
-	"command_caps": ["ORDER_Attack"],
-	"guard_layer": "WL_Air",
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 155
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 155
-			}]
-		}
-	},
-	"model": [{
-		"layer": "WL_LandHorizontal",
-		"filename": "/pa/units/land/air_defense_adv/air_defense_adv.papa",
-		"animtree": "/pa/anim/anim_trees/air_defense_adv_anim_tree.json",
-		"skirt_decal": "/pa/effects/specs/skirt_air_defense_adv.json"
-	},
-	{
-		"layer": "WL_WaterSurface",
-		"filename": "/pa/units/sea/air_defense_adv/air_defense_adv.papa",
-		"animtree": "/pa/anim/anim_trees/fabrication_turret_anim_tree.json"
-	}],
-	"nearby_target_tick_update_interval": 3,
-	"tools": [{
-		"spec_id": "/pa/units/land/air_defense_adv/air_defense_adv_tool_weapon.json",
-		"aim_bone": "bone_pitch",
-		"muzzle_bone": ["socket_rightMuzzle01",
-		"socket_leftMuzzle01",
-		"socket_rightMuzzle02",
-		"socket_leftMuzzle02"]
-	}],
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/structure_small"
-		},
-		"fired": {
-			"audio_cue": "/SE/Weapons/structure/air_defense_flak_fire",
-			"effect_spec": "/pa/effects/specs/default_muzzle_flash.pfx socket_rightMuzzle01 /pa/effects/specs/default_muzzle_flash.pfx socket_leftMuzzle01"
-		},
-		"died": {
-			"audio_cue": "/SE/Death/structure_small",
-			"effect_scale": 0.5
-		}
-	},
-		"fx_offsets": [{
-		"type": "idle",
-		"bone": "socket_leftMuzzle01",
-		"filename": "/pa/units/land/air_defense_adv/aa_lights.pfx",
-		"offset" : [0, 4.5, 1.55]
-	}, {
-		"type" : "idle",
-		"bone" : "socket_rightMuzzle01",
-		"filename": "/pa/units/land/air_defense_adv/aa_lights.pfx",
-		"offset" : [0, 4.5, 1.55]
-		}],
-	"mesh_bounds": [7,
-	7,
-	9.4],
-	"TEMP_texelinfo": 9.09853
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:flak_cannon.message):Flak Cannon",
+  "description": "!LOC(units:advanced_turret_equipped_with_anti_air_turret.message):Advanced turret- Equipped with anti-air turret.",
+  "max_health": 2000,
+  "build_metal_cost": 900,
+  "atrophy_rate": 26.66667,
+  "atrophy_cool_down": 15,
+  "area_build_separation": 18,
+  "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
+  "unit_types": [
+    "UNITTYPE_Structure",
+    "UNITTYPE_Advanced",
+    "UNITTYPE_Land",
+    "UNITTYPE_AirDefense",
+    "UNITTYPE_Defense",
+    "UNITTYPE_FabAdvBuild"
+  ],
+  "command_caps": [
+    "ORDER_Attack"
+  ],
+  "guard_layer": "WL_Air",
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 155
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 155
+        }
+      ]
+    }
+  },
+  "model": [
+    {
+      "layer": "WL_LandHorizontal",
+      "filename": "/pa/units/land/air_defense_adv/air_defense_adv.papa",
+      "animtree": "/pa/anim/anim_trees/air_defense_adv_anim_tree.json",
+      "skirt_decal": "/pa/effects/specs/skirt_air_defense_adv.json"
+    },
+    {
+      "layer": "WL_WaterSurface",
+      "filename": "/pa/units/sea/air_defense_adv/air_defense_adv.papa",
+      "animtree": "/pa/anim/anim_trees/fabrication_turret_anim_tree.json"
+    }
+  ],
+  "nearby_target_tick_update_interval": 3,
+  "tools": [
+    {
+      "spec_id": "/pa/units/land/air_defense_adv/air_defense_adv_tool_weapon.json",
+      "aim_bone": "bone_pitch",
+      "muzzle_bone": [
+        "socket_rightMuzzle01",
+        "socket_leftMuzzle01",
+        "socket_rightMuzzle02",
+        "socket_leftMuzzle02"
+      ]
+    }
+  ],
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/structure_small"
+    },
+    "fired": {
+      "audio_cue": "/SE/Weapons/structure/air_defense_flak_fire",
+      "effect_spec": "/pa/effects/specs/default_muzzle_flash.pfx socket_rightMuzzle01 /pa/effects/specs/default_muzzle_flash.pfx socket_leftMuzzle01"
+    },
+    "died": {
+      "audio_cue": "/SE/Death/structure_small",
+      "effect_scale": 0.5
+    }
+  },
+  "mesh_bounds": [
+    7,
+    7,
+    9.4
+  ],
+  "TEMP_texelinfo": 9.09853,
+  "fx_offsets": [
+    {
+      "type": "idle",
+      "bone": "socket_leftMuzzle01",
+      "filename": "/pa/units/land/air_defense_adv/aa_lights.pfx",
+      "offset": [
+        0,
+        4.5,
+        1.55
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_rightMuzzle01",
+      "filename": "/pa/units/land/air_defense_adv/aa_lights.pfx",
+      "offset": [
+        0,
+        4.5,
+        1.55
+      ]
+    }
+  ]
 }

--- a/pa/units/land/anti_nuke_launcher/anti_nuke_launcher.json
+++ b/pa/units/land/anti_nuke_launcher/anti_nuke_launcher.json
@@ -1,174 +1,285 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:anti_nuke_launcher.message):Anti-Nuke Launcher",
-	"description": "!LOC(units:anti_nuke_launcher_equipped_with_advanced_anti_nuclear_missile_weapon.message):Anti-nuke launcher- Equipped with advanced anti-nuclear missile weapon.",
-	"max_health": 3500,
-	"build_metal_cost": 12000,
-	"atrophy_rate": 200,
-	"atrophy_cool_down": 15,
-	"area_build_type": "Sphere",
-	"area_build_separation": 100,
-	"spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
-	"buildable_projectiles": ["/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_ammo.json"],
-	"factory_cooldown_time": 5,
-	"factory": {
-		"store_units": true,
-		"spawn_points": ["socket_missile01",
-		"socket_missile02",
-		"socket_missile03"],
-		"initial_build_spec": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_ammo.json",
-		"default_build_stance": "Continuous"
-	},
-	"unit_types": ["UNITTYPE_Land",
-	"UNITTYPE_Structure",
-	"UNITTYPE_Defense",
-	"UNITTYPE_NukeDefense",
-	"UNITTYPE_Advanced",
-	"UNITTYPE_Factory",
-	"UNITTYPE_FabAdvBuild",
-	"UNITTYPE_Important"],
-	"command_caps": ["ORDER_FactoryBuild"],
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			},
-			{
-				"layer": "surface_and_air",
-				"channel": "radar",
-				"shape": "capsule",
-				"radius": 310
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			}]
-		}
-	},
-	"model": [{
-		"layer": "WL_LandHorizontal",
-		"filename": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher.papa",
-		"skirt_decal": "/pa/effects/specs/skirt_antinuke.json",
-		"animations": {
-			"idle": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_idle.papa",
-			"build_start_1": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildStart01.papa",
-			"build_loop_1": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildLoop01.papa",
-			"build_end_1": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildEnd01.papa",
-			"build_start_2": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildStart02.papa",
-			"build_loop_2": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildLoop02.papa",
-			"build_end_2": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildEnd02.papa",
-			"build_start_3": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildStart03.papa",
-			"build_loop_3": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildLoop03.papa",
-			"build_end_3": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildEnd03.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/anti_nuke_anim_tree.json"
-	},
-	{
-		"layer": "WL_WaterSurface",
-		"filename": "/pa/units/sea/anti_nuke_launcher/anti_nuke_launcher.papa",
-		"animations": {
-			"build_start_1": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildStart01.papa",
-			"build_loop_1": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildLoop01.papa",
-			"build_end_1": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildEnd01.papa",
-			"build_start_2": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildStart02.papa",
-			"build_loop_2": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildLoop02.papa",
-			"build_end_2": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildEnd02.papa",
-			"build_start_3": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildStart03.papa",
-			"build_loop_3": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildLoop03.papa",
-			"build_end_3": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildEnd03.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/anti_nuke_anim_tree.json"
-	}],
-	"tools": [{
-		"spec_id": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_build_arm.json",
-		"aim_bone": "bone_root"
-	},
-	{
-		"spec_id": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_tool_weapon.json",
-		"aim_bone": "bone_root",
-		"muzzle_bone": "bone_root"
-	}],
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/factory"
-		},
-		"fired": {
-			"audio_cue": "/SE/Weapons/structure/anti_nuke_launcher_fire"
-		},
-		"died": {
-			"audio_cue": "/SE/Death/Factory",
-			"effect_spec": "/pa/effects/specs/default_building_explosion.pfx"
-		}
-	},
-	"audio": {
-		"loops": {
-			"build": {
-				"cue": "/SE/Construction/Factory_contruction_loop_antinuke",
-				"flag": "build_target_changed",
-				"should_start_func": "has_build_target",
-				"should_stop_func": "no_build_target"
-			}
-		},
-		"selection_response": {
-			"cue": "/SE/Selection/structure/anti_nuke"
-		}
-	},
-	"lamps": [{
-		"offset": [1.64,
-		-0.7,
-		-0.87],
-		"radius": 3,
-		"color": [0.1,
-		1,
-		0.1],
-		"intensity": 5,
-		"bone": "bone_rightShoulder"
-	},
-	{
-		"offset": [1.64,
-		-0.7,
-		0.87],
-		"radius": 3,
-		"color": [0.1,
-		1,
-		0.1],
-		"intensity": 5,
-		"bone": "bone_leftShoulder"
-	}],
-	"fx_offsets": [{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "bone_rightWrist",
-		"offset": [1,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		-90]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "bone_leftWrist",
-		"offset": [1,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		-90]
-	}, {
-			"type" : "idle",
-			"bone" : "bone_radarPitch",
-			"filename" : "/pa/effects/specs/light_2_2_2.pfx",
-			"offset" : [3.5, 0, 0]
-		}],
-	"TEMP_texelinfo": 21.7597,
-	"mesh_bounds": [18.5,
-	19.5,
-	15]
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:anti_nuke_launcher.message):Anti-Nuke Launcher",
+  "description": "!LOC(units:anti_nuke_launcher_equipped_with_advanced_anti_nuclear_missile_weapon.message):Anti-nuke launcher- Equipped with advanced anti-nuclear missile weapon.",
+  "max_health": 3500,
+  "build_metal_cost": 12000,
+  "atrophy_rate": 200,
+  "atrophy_cool_down": 15,
+  "area_build_type": "Sphere",
+  "area_build_separation": 100,
+  "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
+  "buildable_projectiles": [
+    "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_ammo.json"
+  ],
+  "factory_cooldown_time": 5,
+  "factory": {
+    "store_units": true,
+    "spawn_points": [
+      "socket_missile01",
+      "socket_missile02",
+      "socket_missile03"
+    ],
+    "initial_build_spec": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_ammo.json",
+    "default_build_stance": "Continuous"
+  },
+  "unit_types": [
+    "UNITTYPE_Land",
+    "UNITTYPE_Structure",
+    "UNITTYPE_Defense",
+    "UNITTYPE_NukeDefense",
+    "UNITTYPE_Advanced",
+    "UNITTYPE_Factory",
+    "UNITTYPE_FabAdvBuild",
+    "UNITTYPE_Important"
+  ],
+  "command_caps": [
+    "ORDER_FactoryBuild"
+  ],
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        },
+        {
+          "layer": "surface_and_air",
+          "channel": "radar",
+          "shape": "capsule",
+          "radius": 310
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        }
+      ]
+    }
+  },
+  "model": [
+    {
+      "layer": "WL_LandHorizontal",
+      "filename": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher.papa",
+      "skirt_decal": "/pa/effects/specs/skirt_antinuke.json",
+      "animations": {
+        "idle": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_idle.papa",
+        "build_start_1": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildStart01.papa",
+        "build_loop_1": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildLoop01.papa",
+        "build_end_1": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildEnd01.papa",
+        "build_start_2": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildStart02.papa",
+        "build_loop_2": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildLoop02.papa",
+        "build_end_2": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildEnd02.papa",
+        "build_start_3": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildStart03.papa",
+        "build_loop_3": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildLoop03.papa",
+        "build_end_3": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildEnd03.papa"
+      },
+      "animtree": "/pa/anim/anim_trees/anti_nuke_anim_tree.json"
+    },
+    {
+      "layer": "WL_WaterSurface",
+      "filename": "/pa/units/sea/anti_nuke_launcher/anti_nuke_launcher.papa",
+      "animations": {
+        "build_start_1": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildStart01.papa",
+        "build_loop_1": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildLoop01.papa",
+        "build_end_1": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildEnd01.papa",
+        "build_start_2": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildStart02.papa",
+        "build_loop_2": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildLoop02.papa",
+        "build_end_2": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildEnd02.papa",
+        "build_start_3": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildStart03.papa",
+        "build_loop_3": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildLoop03.papa",
+        "build_end_3": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_anim_buildEnd03.papa"
+      },
+      "animtree": "/pa/anim/anim_trees/anti_nuke_anim_tree.json"
+    }
+  ],
+  "tools": [
+    {
+      "spec_id": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_build_arm.json",
+      "aim_bone": "bone_root"
+    },
+    {
+      "spec_id": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_tool_weapon.json",
+      "aim_bone": "bone_root",
+      "muzzle_bone": "bone_root"
+    }
+  ],
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/factory"
+    },
+    "fired": {
+      "audio_cue": "/SE/Weapons/structure/anti_nuke_launcher_fire"
+    },
+    "died": {
+      "audio_cue": "/SE/Death/Factory",
+      "effect_spec": "/pa/effects/specs/default_building_explosion.pfx"
+    }
+  },
+  "audio": {
+    "loops": {
+      "build": {
+        "cue": "/SE/Construction/Factory_contruction_loop_antinuke",
+        "flag": "build_target_changed",
+        "should_start_func": "has_build_target",
+        "should_stop_func": "no_build_target"
+      }
+    },
+    "selection_response": {
+      "cue": "/SE/Selection/structure/anti_nuke"
+    }
+  },
+  "lamps": [
+    {
+      "offset": [
+        1.64,
+        -0.7,
+        -0.87
+      ],
+      "radius": 3,
+      "color": [
+        0.1,
+        1,
+        0.1
+      ],
+      "intensity": 5,
+      "bone": "bone_rightShoulder"
+    },
+    {
+      "offset": [
+        1.64,
+        -0.7,
+        0.87
+      ],
+      "radius": 3,
+      "color": [
+        0.1,
+        1,
+        0.1
+      ],
+      "intensity": 5,
+      "bone": "bone_leftShoulder"
+    }
+  ],
+  "fx_offsets": [
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "bone_rightWrist",
+      "offset": [
+        1,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        -90
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "bone_leftWrist",
+      "offset": [
+        1,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        -90
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_radarPitch",
+      "filename": "/pa/effects/specs/light_2_2_2.pfx",
+      "offset": [
+        3.5,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_radarPitch",
+      "filename": "/pa/effects/specs/light_2_2_2.pfx",
+      "offset": [
+        3.5,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_radarPitch",
+      "filename": "/pa/effects/specs/light_2_2_2.pfx",
+      "offset": [
+        3.5,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_radarPitch",
+      "filename": "/pa/effects/specs/light_2_2_2.pfx",
+      "offset": [
+        3.5,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_radarPitch",
+      "filename": "/pa/effects/specs/light_2_2_2.pfx",
+      "offset": [
+        3.5,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_radarPitch",
+      "filename": "/pa/effects/specs/light_2_2_2.pfx",
+      "offset": [
+        3.5,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_radarPitch",
+      "filename": "/pa/effects/specs/light_2_2_2.pfx",
+      "offset": [
+        3.5,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_radarPitch",
+      "filename": "/pa/effects/specs/light_2_2_2.pfx",
+      "offset": [
+        3.5,
+        0,
+        0
+      ]
+    }
+  ],
+  "TEMP_texelinfo": 21.7597,
+  "mesh_bounds": [
+    18.5,
+    19.5,
+    15
+  ]
 }

--- a/pa/units/land/bot_factory/bot_factory.json
+++ b/pa/units/land/bot_factory/bot_factory.json
@@ -1,241 +1,1239 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:bot_factory.message):Bot Factory",
-	"description": "!LOC(units:basic_manufacturing_builds_bots.message):Basic manufacturing- Builds bots.",
-	"max_health": 6000,
-	"build_metal_cost": 600,
-	"atrophy_rate": 10.0,
-	"atrophy_cool_down": 15.0,
-	"buildable_types": "Bot & Mobile & Basic & FactoryBuild",
-	"rolloff_dirs": [[0,
-	1,
-	0],
-	[0,
-	-1,
-	0]],
-	"wait_to_rolloff_time": 0,
-	"factory_cooldown_time": 3,
-	"unit_types": ["UNITTYPE_Factory",
-	"UNITTYPE_Construction",
-	"UNITTYPE_Land",
-	"UNITTYPE_Bot",
-	"UNITTYPE_Structure",
-	"UNITTYPE_Basic",
-	"UNITTYPE_CmdBuild",
-	"UNITTYPE_FabBuild",
-	"UNITTYPE_FabAdvBuild",
-	"UNITTYPE_Important"],
-	"command_caps": ["ORDER_Move",
-	"ORDER_Patrol",
-	"ORDER_FactoryBuild",
-	"ORDER_Reclaim",
-	"ORDER_Repair",
-	"ORDER_Attack",
-	"ORDER_Assist",
-	"ORDER_Use"],
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 110
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 110
-			}]
-		}
-	},
-	"model": {
-		"filename": "/pa/units/land/bot_factory/bot_factory.papa",
-		"animations": {
-			"idle": "/pa/units/land/bot_factory/bot_factory_anim_build.papa",
-			"build_start": "/pa/units/land/bot_factory/bot_factory_anim_start.papa",
-			"build_loop": "/pa/units/land/bot_factory/bot_factory_anim_build.papa",
-			"build_end": "/pa/units/land/bot_factory/bot_factory_anim_end.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/factory_anim_tree.json",
-		"skirt_decal": "/pa/effects/specs/skirt_bot.json"
-	},
-	"tools": [{
-		"spec_id": "/pa/units/land/bot_factory/bot_factory_build_arm.json",
-		"aim_bone": "bone_root"
-	}],
-	"events": {
-		"died": {
-			"effect_scale": 1.0
-		}
-	},
-	"audio": {
-		"loops": {
-			"build": {
-				"cue": "/SE/Construction/Factory_contruction_loop_bot",
-				"flag": "build_target_changed",
-				"should_start_func": "has_build_target",
-				"should_stop_func": "no_build_target"
-			}
-		}
-	},
-	"fx_offsets": [{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_muzzle01",
-		"offset": [0,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_muzzle02",
-		"offset": [0,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	}, {
-			"type" : "build",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/land/bot_factory/light_build.pfx",
-			"offset" : [23.5, -1.15, 4.8]
-		}, {
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/land/bot_factory/dot_1.pfx",
-			"offset" : [23.5, -1.15, 4.8]
-		}, {
-			"type" : "build",
-			"bone" : "bone_armShoulder01",
-			"filename" : "/pa/units/land/bot_factory/light_build_bone.pfx",
-			"offset" : [2.5, 1.3, -1.4]
-		}, {
-			"type" : "build",
-			"bone" : "bone_armShoulder02",
-			"filename" : "/pa/units/land/bot_factory/light_build_bone.pfx",
-			"offset" : [2.5, 1.3, 1.4]
-		}, {
-			"type" : "idle",
-			"bone" : "bone_armShoulder01",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset" : [2.5, 1.3, -1.4]
-		}, {
-			"type" : "idle",
-			"bone" : "bone_armShoulder02",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset" : [2.5, 1.3, 1.4]
-		}, {
-			"label" : "RAMP FIRST RIGHT",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
-			"offset" : [3.7, 8.2, 3.3]
-		}, {
-			"label" : "RAMP SECOND RIGHT",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
-			"offset" : [3.7, 10.8, 2.3]
-		}, {
-			"label" : "RAMP THIRD RIGHT",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
-			"offset" : [3.7, 13.2, 1.3]
-		}, {
-			"label" : "RAMP FIRST LEFT",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
-			"offset" : [3.7, -9.8, 3.3]
-		}, {
-			"label" : "RAMP SECOND LEFT",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
-			"offset" : [3.7, -12.2, 2.3]
-		}, {
-			"label" : "RAMP THIRD LEFT",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
-			"offset" : [3.7, -14.8, 1.3]
-		}],
-	"death": {
-		"decals": ["/pa/effects/specs/scorch_c_01.json"]
-	},
-	"headlights": [{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [-8.1,
-		0.0,
-		10.58],
-		"orientation": [45.0,
-		0.0,
-		0.0],
-		"near_width": 12.0,
-		"near_height": 12.0,
-		"near_distance": 5.0,
-		"far_distance": 20.0,
-		"color": [1.5,
-		1.52,
-		1.6],
-		"intensity": 2.0,
-		"debug": false
-	}],
-	"lamps": [{
-		"offset": [-8.1,
-		0.0,
-		10.0],
-		"radius": 4.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-8.1,
-		0.0,
-		11.4],
-		"radius": 4.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [12.63,
-		0.0,
-		9.15],
-		"radius": 8.0,
-		"color": [0.1,
-		1.0,
-		0.1],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-15.47,
-		0.0,
-		9.94],
-		"radius": 4.0,
-		"color": [1.0,
-		0.0,
-		0.0],
-		"intensity": 2.0
-	}],
-	"mesh_bounds": [29.5,
-	30.5,
-	15.2],
-	"placement_size": [30,
-	60],
-	"area_build_separation": 3,
-	"TEMP_texelinfo": 38.3936,
-	"physics": {
-		"collision_layers": "WL_AnyHorizontalGroundOrWaterSurface"
-	}
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:bot_factory.message):Bot Factory",
+  "description": "!LOC(units:basic_manufacturing_builds_bots.message):Basic manufacturing- Builds bots.",
+  "max_health": 6000,
+  "build_metal_cost": 600,
+  "atrophy_rate": 10.0,
+  "atrophy_cool_down": 15.0,
+  "buildable_types": "Bot & Mobile & Basic & FactoryBuild",
+  "rolloff_dirs": [
+    [
+      0,
+      1,
+      0
+    ],
+    [
+      0,
+      -1,
+      0
+    ]
+  ],
+  "wait_to_rolloff_time": 0,
+  "factory_cooldown_time": 3,
+  "unit_types": [
+    "UNITTYPE_Factory",
+    "UNITTYPE_Construction",
+    "UNITTYPE_Land",
+    "UNITTYPE_Bot",
+    "UNITTYPE_Structure",
+    "UNITTYPE_Basic",
+    "UNITTYPE_CmdBuild",
+    "UNITTYPE_FabBuild",
+    "UNITTYPE_FabAdvBuild",
+    "UNITTYPE_Important"
+  ],
+  "command_caps": [
+    "ORDER_Move",
+    "ORDER_Patrol",
+    "ORDER_FactoryBuild",
+    "ORDER_Reclaim",
+    "ORDER_Repair",
+    "ORDER_Attack",
+    "ORDER_Assist",
+    "ORDER_Use"
+  ],
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 110
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 110
+        }
+      ]
+    }
+  },
+  "model": {
+    "filename": "/pa/units/land/bot_factory/bot_factory.papa",
+    "animations": {
+      "idle": "/pa/units/land/bot_factory/bot_factory_anim_build.papa",
+      "build_start": "/pa/units/land/bot_factory/bot_factory_anim_start.papa",
+      "build_loop": "/pa/units/land/bot_factory/bot_factory_anim_build.papa",
+      "build_end": "/pa/units/land/bot_factory/bot_factory_anim_end.papa"
+    },
+    "animtree": "/pa/anim/anim_trees/factory_anim_tree.json",
+    "skirt_decal": "/pa/effects/specs/skirt_bot.json"
+  },
+  "tools": [
+    {
+      "spec_id": "/pa/units/land/bot_factory/bot_factory_build_arm.json",
+      "aim_bone": "bone_root"
+    }
+  ],
+  "events": {
+    "died": {
+      "effect_scale": 1.0
+    }
+  },
+  "audio": {
+    "loops": {
+      "build": {
+        "cue": "/SE/Construction/Factory_contruction_loop_bot",
+        "flag": "build_target_changed",
+        "should_start_func": "has_build_target",
+        "should_stop_func": "no_build_target"
+      }
+    }
+  },
+  "fx_offsets": [
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_muzzle01",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_muzzle02",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/light_build.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/dot_1.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armShoulder01",
+      "filename": "/pa/units/land/bot_factory/light_build_bone.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        -1.4
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armShoulder02",
+      "filename": "/pa/units/land/bot_factory/light_build_bone.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        1.4
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armShoulder01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        -1.4
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armShoulder02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        1.4
+      ]
+    },
+    {
+      "label": "RAMP FIRST RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        8.2,
+        3.3
+      ]
+    },
+    {
+      "label": "RAMP SECOND RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        10.8,
+        2.3
+      ]
+    },
+    {
+      "label": "RAMP THIRD RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        13.2,
+        1.3
+      ]
+    },
+    {
+      "label": "RAMP FIRST LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -9.8,
+        3.3
+      ]
+    },
+    {
+      "label": "RAMP SECOND LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -12.2,
+        2.3
+      ]
+    },
+    {
+      "label": "RAMP THIRD LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -14.8,
+        1.3
+      ]
+    },
+    {
+      "label": "RAMP THIRD LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -14.8,
+        1.3
+      ]
+    },
+    {
+      "label": "RAMP SECOND LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -12.2,
+        2.3
+      ]
+    },
+    {
+      "label": "RAMP FIRST LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -9.8,
+        3.3
+      ]
+    },
+    {
+      "label": "RAMP THIRD RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        13.2,
+        1.3
+      ]
+    },
+    {
+      "label": "RAMP SECOND RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        10.8,
+        2.3
+      ]
+    },
+    {
+      "label": "RAMP FIRST RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        8.2,
+        3.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armShoulder02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        1.4
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armShoulder01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        -1.4
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armShoulder02",
+      "filename": "/pa/units/land/bot_factory/light_build_bone.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        1.4
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armShoulder01",
+      "filename": "/pa/units/land/bot_factory/light_build_bone.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        -1.4
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/dot_1.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/light_build.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/light_build.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/dot_1.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armShoulder01",
+      "filename": "/pa/units/land/bot_factory/light_build_bone.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        -1.4
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armShoulder02",
+      "filename": "/pa/units/land/bot_factory/light_build_bone.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        1.4
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armShoulder01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        -1.4
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armShoulder02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        1.4
+      ]
+    },
+    {
+      "label": "RAMP FIRST RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        8.2,
+        3.3
+      ]
+    },
+    {
+      "label": "RAMP SECOND RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        10.8,
+        2.3
+      ]
+    },
+    {
+      "label": "RAMP THIRD RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        13.2,
+        1.3
+      ]
+    },
+    {
+      "label": "RAMP FIRST LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -9.8,
+        3.3
+      ]
+    },
+    {
+      "label": "RAMP SECOND LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -12.2,
+        2.3
+      ]
+    },
+    {
+      "label": "RAMP THIRD LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -14.8,
+        1.3
+      ]
+    },
+    {
+      "label": "RAMP THIRD LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -14.8,
+        1.3
+      ]
+    },
+    {
+      "label": "RAMP SECOND LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -12.2,
+        2.3
+      ]
+    },
+    {
+      "label": "RAMP FIRST LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -9.8,
+        3.3
+      ]
+    },
+    {
+      "label": "RAMP THIRD RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        13.2,
+        1.3
+      ]
+    },
+    {
+      "label": "RAMP SECOND RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        10.8,
+        2.3
+      ]
+    },
+    {
+      "label": "RAMP FIRST RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        8.2,
+        3.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armShoulder02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        1.4
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armShoulder01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        -1.4
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armShoulder02",
+      "filename": "/pa/units/land/bot_factory/light_build_bone.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        1.4
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armShoulder01",
+      "filename": "/pa/units/land/bot_factory/light_build_bone.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        -1.4
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/dot_1.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/light_build.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/light_build.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/dot_1.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armShoulder01",
+      "filename": "/pa/units/land/bot_factory/light_build_bone.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        -1.4
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armShoulder02",
+      "filename": "/pa/units/land/bot_factory/light_build_bone.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        1.4
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armShoulder01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        -1.4
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armShoulder02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        1.4
+      ]
+    },
+    {
+      "label": "RAMP FIRST RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        8.2,
+        3.3
+      ]
+    },
+    {
+      "label": "RAMP SECOND RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        10.8,
+        2.3
+      ]
+    },
+    {
+      "label": "RAMP THIRD RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        13.2,
+        1.3
+      ]
+    },
+    {
+      "label": "RAMP FIRST LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -9.8,
+        3.3
+      ]
+    },
+    {
+      "label": "RAMP SECOND LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -12.2,
+        2.3
+      ]
+    },
+    {
+      "label": "RAMP THIRD LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -14.8,
+        1.3
+      ]
+    },
+    {
+      "label": "RAMP THIRD LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -14.8,
+        1.3
+      ]
+    },
+    {
+      "label": "RAMP SECOND LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -12.2,
+        2.3
+      ]
+    },
+    {
+      "label": "RAMP FIRST LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -9.8,
+        3.3
+      ]
+    },
+    {
+      "label": "RAMP THIRD RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        13.2,
+        1.3
+      ]
+    },
+    {
+      "label": "RAMP SECOND RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        10.8,
+        2.3
+      ]
+    },
+    {
+      "label": "RAMP FIRST RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        8.2,
+        3.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armShoulder02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        1.4
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armShoulder01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        -1.4
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armShoulder02",
+      "filename": "/pa/units/land/bot_factory/light_build_bone.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        1.4
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armShoulder01",
+      "filename": "/pa/units/land/bot_factory/light_build_bone.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        -1.4
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/dot_1.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/light_build.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/light_build.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/dot_1.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armShoulder01",
+      "filename": "/pa/units/land/bot_factory/light_build_bone.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        -1.4
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armShoulder02",
+      "filename": "/pa/units/land/bot_factory/light_build_bone.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        1.4
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armShoulder01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        -1.4
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armShoulder02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        1.4
+      ]
+    },
+    {
+      "label": "RAMP FIRST RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        8.2,
+        3.3
+      ]
+    },
+    {
+      "label": "RAMP SECOND RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        10.8,
+        2.3
+      ]
+    },
+    {
+      "label": "RAMP THIRD RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        13.2,
+        1.3
+      ]
+    },
+    {
+      "label": "RAMP FIRST LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -9.8,
+        3.3
+      ]
+    },
+    {
+      "label": "RAMP SECOND LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -12.2,
+        2.3
+      ]
+    },
+    {
+      "label": "RAMP THIRD LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -14.8,
+        1.3
+      ]
+    },
+    {
+      "label": "RAMP THIRD LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -14.8,
+        1.3
+      ]
+    },
+    {
+      "label": "RAMP SECOND LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -12.2,
+        2.3
+      ]
+    },
+    {
+      "label": "RAMP FIRST LEFT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        -9.8,
+        3.3
+      ]
+    },
+    {
+      "label": "RAMP THIRD RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        13.2,
+        1.3
+      ]
+    },
+    {
+      "label": "RAMP SECOND RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        10.8,
+        2.3
+      ]
+    },
+    {
+      "label": "RAMP FIRST RIGHT",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+      "offset": [
+        3.7,
+        8.2,
+        3.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armShoulder02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        1.4
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armShoulder01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        -1.4
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armShoulder02",
+      "filename": "/pa/units/land/bot_factory/light_build_bone.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        1.4
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armShoulder01",
+      "filename": "/pa/units/land/bot_factory/light_build_bone.pfx",
+      "offset": [
+        2.5,
+        1.3,
+        -1.4
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/dot_1.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory/light_build.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    }
+  ],
+  "death": {
+    "decals": [
+      "/pa/effects/specs/scorch_c_01.json"
+    ]
+  },
+  "headlights": [
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        -8.1,
+        0.0,
+        10.58
+      ],
+      "orientation": [
+        45.0,
+        0.0,
+        0.0
+      ],
+      "near_width": 12.0,
+      "near_height": 12.0,
+      "near_distance": 5.0,
+      "far_distance": 20.0,
+      "color": [
+        1.5,
+        1.52,
+        1.6
+      ],
+      "intensity": 2.0,
+      "debug": false
+    }
+  ],
+  "lamps": [
+    {
+      "offset": [
+        -8.1,
+        0.0,
+        10.0
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -8.1,
+        0.0,
+        11.4
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        12.63,
+        0.0,
+        9.15
+      ],
+      "radius": 8.0,
+      "color": [
+        0.1,
+        1.0,
+        0.1
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -15.47,
+        0.0,
+        9.94
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "intensity": 2.0
+    }
+  ],
+  "mesh_bounds": [
+    29.5,
+    30.5,
+    15.2
+  ],
+  "placement_size": [
+    40,
+    55
+  ],
+  "area_build_separation": 2,
+  "TEMP_texelinfo": 38.3936,
+  "physics": {
+    "collision_layers": "WL_AnyHorizontalGroundOrWaterSurface"
+  }
 }

--- a/pa/units/land/bot_factory_adv/bot_factory_adv.json
+++ b/pa/units/land/bot_factory_adv/bot_factory_adv.json
@@ -1,239 +1,905 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:advanced_bot_factory.message):Advanced Bot Factory",
-	"description": "!LOC(units:advanced_manufacturing_builds_bots.message):Advanced manufacturing- Builds bots.",
-	"max_health": 30000,
-	"build_metal_cost": 4800,
-	"atrophy_rate": 80.0,
-	"atrophy_cool_down": 15.0,
-	"buildable_types": "Bot & Mobile & FactoryBuild",
-	"rolloff_dirs": [[0,
-	1,
-	0],
-	[0,
-	-1,
-	0]],
-	"wait_to_rolloff_time": 0,
-	"factory_cooldown_time": 3,
-	"unit_types": ["UNITTYPE_Factory",
-	"UNITTYPE_Construction",
-	"UNITTYPE_Land",
-	"UNITTYPE_Bot",
-	"UNITTYPE_Structure",
-	"UNITTYPE_Advanced",
-	"UNITTYPE_Important"],
-	"command_caps": ["ORDER_Move",
-	"ORDER_Patrol",
-	"ORDER_FactoryBuild",
-	"ORDER_Reclaim",
-	"ORDER_Repair",
-	"ORDER_Attack",
-	"ORDER_Assist",
-	"ORDER_Use"],
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 110
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 110
-			}]
-		}
-	},
-	"model": {
-		"filename": "/pa/units/land/bot_factory_adv/bot_factory_adv.papa",
-		"animations": {
-			"build_start": "/pa/units/land/bot_factory_adv/bot_factory_adv_anim_start.papa",
-			"build_loop": "/pa/units/land/bot_factory_adv/bot_factory_adv_anim_build.papa",
-			"build_end": "/pa/units/land/bot_factory_adv/bot_factory_adv_anim_end.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/factory_anim_tree.json",
-		"skirt_decal": "/pa/effects/specs/skirt_bot_adv.json"
-	},
-	"tools": [{
-		"spec_id": "/pa/units/land/bot_factory_adv/bot_factory_adv_build_arm.json",
-		"aim_bone": "bone_root"
-	}],
-	"events": {
-		"died": {
-			"effect_scale": 1.5
-		}
-	},
-	"audio": {
-		"loops": {
-			"build": {
-				"cue": "/SE/Construction/Factory_contruction_loop_bot",
-				"flag": "build_target_changed",
-				"should_start_func": "has_build_target",
-				"should_stop_func": "no_build_target"
-			}
-		}
-	},
-	"fx_offsets": [{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_muzzle01",
-		"offset": [0,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_muzzle02",
-		"offset": [0,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_muzzle03",
-		"offset": [0,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	}, {
-			"type" : "build",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/land/bot_factory_adv/light_build.pfx",
-			"offset" : [15, 0, 10.7]
-		}, {
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/land/bot_factory_adv/dot_1.pfx",
-			"offset" : [15, 0, 10.7]
-		}, {
-			"type" : "build",
-			"bone" : "bone_armElbow03",
-			"filename" : "/pa/units/land/bot_factory_adv/light_build_bone_1.pfx",
-			"offset" : [3.0, 0.3, 0]
-		}, {
-			"type" : "build",
-			"bone" : "bone_armElbow02",
-			"filename" : "/pa/units/land/bot_factory_adv/light_build_bone_2.pfx",
-			"offset" : [3.0, 0.3, 1.2]
-		}, {
-			"type" : "build",
-			"bone" : "bone_armElbow01",
-			"filename" : "/pa/units/land/bot_factory_adv/light_build_bone_3.pfx",
-			"offset" : [3.0, 0.3, -1.2]
-		}, {
-			"type" : "idle",
-			"bone" : "bone_armElbow03",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset" : [3.0, 0.3, 0]
-		}, {
-			"type" : "idle",
-			"bone" : "bone_armElbow02",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset" : [3.0, 0.3, 1.2]
-		}, {
-			"type" : "idle",
-			"bone" : "bone_armElbow01",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset" : [3.0, 0.3, -1.2]
-		}],
-	"headlights": [{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [-14.29,
-		0.0,
-		16.6],
-		"orientation": [45.0,
-		0.0,
-		0.0],
-		"near_width": 12.0,
-		"near_height": 12.0,
-		"near_distance": 5.0,
-		"far_distance": 40.0,
-		"color": [1.5,
-		1.52,
-		1.6],
-		"intensity": 2.0,
-		"debug": false
-	}],
-	"lamps": [{
-		"offset": [-14.29,
-		0.0,
-		16.0],
-		"radius": 4.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-14.29,
-		0.0,
-		17.2],
-		"radius": 4.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [19.0,
-		0.0,
-		9.67],
-		"radius": 8.0,
-		"color": [0.1,
-		1.0,
-		0.1],
-		"intensity": 2.0
-	},
-	{
-		"offset": [22.73,
-		0.0,
-		14.32],
-		"radius": 8.0,
-		"color": [0.1,
-		1.0,
-		0.1],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-25.27,
-		0.0,
-		14.65],
-		"radius": 4.0,
-		"color": [1.0,
-		0.0,
-		0.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-14.24,
-		-19.53,
-		7.0],
-		"radius": 4.0,
-		"color": [1.0,
-		0.0,
-		0.0],
-		"intensity": 2.0
-	}],
-	"mesh_bounds": [50,
-	50,
-	22],
-	"placement_size": [50,
-	80],
-	"area_build_separation": 7,
-	"TEMP_texelinfo": 63.0516,
-	"physics": {
-		"collision_layers": "WL_AnyHorizontalGroundOrWaterSurface"
-	}
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:advanced_bot_factory.message):Advanced Bot Factory",
+  "description": "!LOC(units:advanced_manufacturing_builds_bots.message):Advanced manufacturing- Builds bots.",
+  "max_health": 30000,
+  "build_metal_cost": 4800,
+  "atrophy_rate": 80.0,
+  "atrophy_cool_down": 15.0,
+  "buildable_types": "Bot & Mobile & FactoryBuild",
+  "rolloff_dirs": [
+    [
+      0,
+      1,
+      0
+    ],
+    [
+      0,
+      -1,
+      0
+    ]
+  ],
+  "wait_to_rolloff_time": 0,
+  "factory_cooldown_time": 3,
+  "unit_types": [
+    "UNITTYPE_Factory",
+    "UNITTYPE_Construction",
+    "UNITTYPE_Land",
+    "UNITTYPE_Bot",
+    "UNITTYPE_Structure",
+    "UNITTYPE_Advanced",
+    "UNITTYPE_Important"
+  ],
+  "command_caps": [
+    "ORDER_Move",
+    "ORDER_Patrol",
+    "ORDER_FactoryBuild",
+    "ORDER_Reclaim",
+    "ORDER_Repair",
+    "ORDER_Attack",
+    "ORDER_Assist",
+    "ORDER_Use"
+  ],
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 110
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 110
+        }
+      ]
+    }
+  },
+  "model": {
+    "filename": "/pa/units/land/bot_factory_adv/bot_factory_adv.papa",
+    "animations": {
+      "build_start": "/pa/units/land/bot_factory_adv/bot_factory_adv_anim_start.papa",
+      "build_loop": "/pa/units/land/bot_factory_adv/bot_factory_adv_anim_build.papa",
+      "build_end": "/pa/units/land/bot_factory_adv/bot_factory_adv_anim_end.papa"
+    },
+    "animtree": "/pa/anim/anim_trees/factory_anim_tree.json",
+    "skirt_decal": "/pa/effects/specs/skirt_bot_adv.json"
+  },
+  "tools": [
+    {
+      "spec_id": "/pa/units/land/bot_factory_adv/bot_factory_adv_build_arm.json",
+      "aim_bone": "bone_root"
+    }
+  ],
+  "events": {
+    "died": {
+      "effect_scale": 1.5
+    }
+  },
+  "audio": {
+    "loops": {
+      "build": {
+        "cue": "/SE/Construction/Factory_contruction_loop_bot",
+        "flag": "build_target_changed",
+        "should_start_func": "has_build_target",
+        "should_stop_func": "no_build_target"
+      }
+    }
+  },
+  "fx_offsets": [
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_muzzle01",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_muzzle02",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_muzzle03",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory_adv/light_build.pfx",
+      "offset": [
+        15,
+        0,
+        10.7
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory_adv/dot_1.pfx",
+      "offset": [
+        15,
+        0,
+        10.7
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow03",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow02",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        1.2
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow01",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        -1.2
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        1.2
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        -1.2
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        -1.2
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        1.2
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow01",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        -1.2
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow02",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        1.2
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow03",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory_adv/dot_1.pfx",
+      "offset": [
+        15,
+        0,
+        10.7
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory_adv/light_build.pfx",
+      "offset": [
+        15,
+        0,
+        10.7
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory_adv/light_build.pfx",
+      "offset": [
+        15,
+        0,
+        10.7
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory_adv/dot_1.pfx",
+      "offset": [
+        15,
+        0,
+        10.7
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow03",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow02",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        1.2
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow01",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        -1.2
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        1.2
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        -1.2
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        -1.2
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        1.2
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow01",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        -1.2
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow02",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        1.2
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow03",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory_adv/dot_1.pfx",
+      "offset": [
+        15,
+        0,
+        10.7
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory_adv/light_build.pfx",
+      "offset": [
+        15,
+        0,
+        10.7
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory_adv/light_build.pfx",
+      "offset": [
+        15,
+        0,
+        10.7
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory_adv/dot_1.pfx",
+      "offset": [
+        15,
+        0,
+        10.7
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow03",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow02",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        1.2
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow01",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        -1.2
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        1.2
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        -1.2
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        -1.2
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        1.2
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow01",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        -1.2
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow02",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        1.2
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow03",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory_adv/dot_1.pfx",
+      "offset": [
+        15,
+        0,
+        10.7
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory_adv/light_build.pfx",
+      "offset": [
+        15,
+        0,
+        10.7
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory_adv/light_build.pfx",
+      "offset": [
+        15,
+        0,
+        10.7
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory_adv/dot_1.pfx",
+      "offset": [
+        15,
+        0,
+        10.7
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow03",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow02",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        1.2
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow01",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        -1.2
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        1.2
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        -1.2
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        -1.2
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow02",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        1.2
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_armElbow03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow01",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        -1.2
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow02",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        1.2
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_armElbow03",
+      "filename": "/pa/units/land/bot_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        3.0,
+        0.3,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory_adv/dot_1.pfx",
+      "offset": [
+        15,
+        0,
+        10.7
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/bot_factory_adv/light_build.pfx",
+      "offset": [
+        15,
+        0,
+        10.7
+      ]
+    }
+  ],
+  "headlights": [
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        -14.29,
+        0.0,
+        16.6
+      ],
+      "orientation": [
+        45.0,
+        0.0,
+        0.0
+      ],
+      "near_width": 12.0,
+      "near_height": 12.0,
+      "near_distance": 5.0,
+      "far_distance": 40.0,
+      "color": [
+        1.5,
+        1.52,
+        1.6
+      ],
+      "intensity": 2.0,
+      "debug": false
+    }
+  ],
+  "lamps": [
+    {
+      "offset": [
+        -14.29,
+        0.0,
+        16.0
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -14.29,
+        0.0,
+        17.2
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        19.0,
+        0.0,
+        9.67
+      ],
+      "radius": 8.0,
+      "color": [
+        0.1,
+        1.0,
+        0.1
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        22.73,
+        0.0,
+        14.32
+      ],
+      "radius": 8.0,
+      "color": [
+        0.1,
+        1.0,
+        0.1
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -25.27,
+        0.0,
+        14.65
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -14.24,
+        -19.53,
+        7.0
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "intensity": 2.0
+    }
+  ],
+  "mesh_bounds": [
+    50,
+    50,
+    22
+  ],
+  "placement_size": [
+    60,
+    80
+  ],
+  "area_build_separation": 2,
+  "TEMP_texelinfo": 63.0516,
+  "physics": {
+    "collision_layers": "WL_AnyHorizontalGroundOrWaterSurface"
+  }
 }

--- a/pa/units/land/control_module/control_module.json
+++ b/pa/units/land/control_module/control_module.json
@@ -1,168 +1,667 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:catalyst.message):Catalyst",
-	"description": "!LOC(units:analysis_controls_things_big_things.message):Analysis: Controls things. Big things.",
-	"max_health": 20000,
-	"build_metal_cost": 40000,
-	"atrophy_rate": 500,
-	"atrophy_cool_down": 15.0,
-	"feature_requirements": ["control_point"],
-	"area_build_type": "Sphere",
-	"force_snap_to_feature_orientation": true,
-	"feature_snap_ignores_pathability": true,
-	"activates_control_point": true,
-	"unit_types": ["UNITTYPE_Structure",
-	"UNITTYPE_ControlModule",
-	"UNITTYPE_Advanced",
-	"UNITTYPE_FabAdvBuild",
-	"UNITTYPE_Important"],
-	"recon": {
-		"observable": {
-			"layer": "surface_and_air",
-			"ignore_radar": true,
-			"always_visible": true
-		},
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			}]
-		}
-	},
-	"model": {
-		"filename": "/pa/units/land/control_module/control_module.papa",
-		"animations": {
-			"start": "/pa/units/land/control_module/control_module_anim_start.papa",
-			"loop": "/pa/units/land/control_module/control_module_anim_loop.papa",
-			"end": "/pa/units/land/control_module/control_module_anim_end.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/powered_loop_anim_tree.json"
-	},
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/control_point"
-		},
-		"died": {
-			"audio_cue": "/SE/Death/control_point",
-			"effect_scale": 7.5
-		}
-	},
-	"fx_offsets" : [{
-			"type" : "idle",
-			"filename" : "/pa/units/land/control_module/control_module_strobe01.pfx",
-			"bone" : "bone_rightArm",
-			"offset" : [0.35, -112.156, 2.578]
-		}, {
-			"type" : "idle",
-			"filename" : "/pa/units/land/control_module/control_module_strobe02.pfx",
-			"bone" : "bone_leftArm",
-			"offset" : [-0.35, -112.156, 2.578]
-		}, {
-			"type" : "idle",
-			"filename" : "/pa/units/land/control_module/control_module_enabled.pfx",
-			"bone" : "bone_conductor02",
-			"offset" : [0, -63, 4]
-		},{
-			"type" : "idle",
-			"filename" : "/pa/units/land/control_module/PulseStrip1.pfx",
-			"bone" : "bone_rightShieldSet",
-			"offset" : [22, -19.8, 4]
-		},{
-			"type" : "idle",
-			"filename" : "/pa/units/land/control_module/PulseStrip2.pfx",
-			"bone" : "bone_rightShieldSet",
-			"offset" : [22, 0.2, 4]
-		},{
-			"type" : "idle",
-			"filename" : "/pa/units/land/control_module/PulseStrip3.pfx",
-			"bone" : "bone_rightShieldSet",
-			"offset" : [22, 20.2, 4]
-		},{
-			"type" : "idle",
-			"filename" : "/pa/units/land/control_module/PulseStrip1.pfx",
-			"bone" : "bone_leftShieldSet",
-			"offset" : [22, 19.8, 4]
-		},{
-			"type" : "idle",
-			"filename" : "/pa/units/land/control_module/PulseStrip2.pfx",
-			"bone" : "bone_leftShieldSet",
-			"offset" : [22, -0.2, 4]
-		},{
-			"type" : "idle",
-			"filename" : "/pa/units/land/control_module/PulseStrip3.pfx",
-			"bone" : "bone_leftShieldSet",
-			"offset" : [22, -20.2, 4]
-		}
-	],
-	"headlights": [{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [5.688,
-		-75.598,
-		12.0],
-		"orientation": [0.0,
-		35.0,
-		0.0],
-		"near_width": 1.0,
-		"near_height": 1.2,
-		"near_distance": 0.5,
-		"far_distance": 15.0,
-		"color": [1.5,
-		1.52,
-		1.6],
-		"intensity": 5.0,
-		"bone": "bone_rightArm"
-	},
-	{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [-5.688,
-		-75.598,
-		12.0],
-		"orientation": [0.0,
-		35.0,
-		0.0],
-		"near_width": 1.0,
-		"near_height": 1.2,
-		"near_distance": 0.5,
-		"far_distance": 15.0,
-		"color": [1.5,
-		1.52,
-		1.6],
-		"intensity": 5.0,
-		"bone": "bone_leftArm"
-	}],
-	"lamps": [{
-		"offset": [-30.126,
-		-44.99,
-		32.0],
-		"radius": 4.0,
-		"color": [1.0,
-		0.0,
-		0.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [30.126,
-		-44.99,
-		32.0],
-		"radius": 4.0,
-		"color": [1.0,
-		0.0,
-		0.0],
-		"intensity": 2.0
-	}],
-	"mesh_bounds": [80,
-	150,
-	100],
-	"placement_size": [100,
-	170,
-	100],
-	"TEMP_texelinfo": 51.0
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:catalyst.message):Catalyst",
+  "description": "!LOC(units:analysis_controls_things_big_things.message):Analysis: Controls things. Big things.",
+  "max_health": 20000,
+  "build_metal_cost": 40000,
+  "atrophy_rate": 500,
+  "atrophy_cool_down": 15.0,
+  "feature_requirements": [
+    "control_point"
+  ],
+  "area_build_type": "Sphere",
+  "force_snap_to_feature_orientation": true,
+  "feature_snap_ignores_pathability": true,
+  "activates_control_point": true,
+  "unit_types": [
+    "UNITTYPE_Structure",
+    "UNITTYPE_ControlModule",
+    "UNITTYPE_Advanced",
+    "UNITTYPE_FabAdvBuild",
+    "UNITTYPE_Important"
+  ],
+  "recon": {
+    "observable": {
+      "layer": "surface_and_air",
+      "ignore_radar": true,
+      "always_visible": true
+    },
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        }
+      ]
+    }
+  },
+  "model": {
+    "filename": "/pa/units/land/control_module/control_module.papa",
+    "animations": {
+      "start": "/pa/units/land/control_module/control_module_anim_start.papa",
+      "loop": "/pa/units/land/control_module/control_module_anim_loop.papa",
+      "end": "/pa/units/land/control_module/control_module_anim_end.papa"
+    },
+    "animtree": "/pa/anim/anim_trees/powered_loop_anim_tree.json"
+  },
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/control_point"
+    },
+    "died": {
+      "audio_cue": "/SE/Death/control_point",
+      "effect_scale": 7.5
+    }
+  },
+  "fx_offsets": [
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/control_module_strobe01.pfx",
+      "bone": "bone_rightArm",
+      "offset": [
+        0.35,
+        -112.156,
+        2.578
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/control_module_strobe02.pfx",
+      "bone": "bone_leftArm",
+      "offset": [
+        -0.35,
+        -112.156,
+        2.578
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/control_module_enabled.pfx",
+      "bone": "bone_conductor02",
+      "offset": [
+        0,
+        -63,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip1.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        -19.8,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip2.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        0.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip3.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        20.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip1.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        19.8,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip2.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        -0.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip3.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        -20.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip3.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        -20.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip2.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        -0.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip1.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        19.8,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip3.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        20.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip2.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        0.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip1.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        -19.8,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip1.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        -19.8,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip2.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        0.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip3.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        20.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip1.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        19.8,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip2.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        -0.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip3.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        -20.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip3.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        -20.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip2.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        -0.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip1.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        19.8,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip3.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        20.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip2.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        0.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip1.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        -19.8,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip1.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        -19.8,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip2.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        0.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip3.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        20.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip1.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        19.8,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip2.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        -0.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip3.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        -20.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip3.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        -20.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip2.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        -0.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip1.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        19.8,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip3.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        20.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip2.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        0.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip1.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        -19.8,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip1.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        -19.8,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip2.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        0.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip3.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        20.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip1.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        19.8,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip2.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        -0.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip3.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        -20.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip3.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        -20.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip2.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        -0.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip1.pfx",
+      "bone": "bone_leftShieldSet",
+      "offset": [
+        22,
+        19.8,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip3.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        20.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip2.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        0.2,
+        4
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/control_module/PulseStrip1.pfx",
+      "bone": "bone_rightShieldSet",
+      "offset": [
+        22,
+        -19.8,
+        4
+      ]
+    }
+  ],
+  "headlights": [
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        5.688,
+        -75.598,
+        12.0
+      ],
+      "orientation": [
+        0.0,
+        35.0,
+        0.0
+      ],
+      "near_width": 1.0,
+      "near_height": 1.2,
+      "near_distance": 0.5,
+      "far_distance": 15.0,
+      "color": [
+        1.5,
+        1.52,
+        1.6
+      ],
+      "intensity": 5.0,
+      "bone": "bone_rightArm"
+    },
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        -5.688,
+        -75.598,
+        12.0
+      ],
+      "orientation": [
+        0.0,
+        35.0,
+        0.0
+      ],
+      "near_width": 1.0,
+      "near_height": 1.2,
+      "near_distance": 0.5,
+      "far_distance": 15.0,
+      "color": [
+        1.5,
+        1.52,
+        1.6
+      ],
+      "intensity": 5.0,
+      "bone": "bone_leftArm"
+    }
+  ],
+  "lamps": [
+    {
+      "offset": [
+        -30.126,
+        -44.99,
+        32.0
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        30.126,
+        -44.99,
+        32.0
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "intensity": 2.0
+    }
+  ],
+  "mesh_bounds": [
+    80,
+    150,
+    100
+  ],
+  "placement_size": [
+    100,
+    170,
+    100
+  ],
+  "TEMP_texelinfo": 51.0
 }

--- a/pa/units/land/energy_plant_adv/energy_plant_adv.json
+++ b/pa/units/land/energy_plant_adv/energy_plant_adv.json
@@ -1,244 +1,540 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:advanced_energy_plant.message):Advanced Energy Plant",
-	"description": "!LOC(units:advanced_manufacturing_produces_energy.message):Advanced manufacturing- Produces energy.",
-	"max_health": 5000,
-	"build_metal_cost": 2700,
-	"atrophy_rate": 45.0,
-	"atrophy_cool_down": 15.0,
-	"spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
-	"area_build_type": "Line",
-	"production": {
-		"energy": 5000
-	},
-	"unit_types": ["UNITTYPE_Structure",
-	"UNITTYPE_EnergyProduction",
-	"UNITTYPE_Advanced",
-	"UNITTYPE_FabAdvBuild",
-	"UNITTYPE_Economy"],
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			}]
-		}
-	},
-	"model": [{
-		"layer": "WL_LandHorizontal",
-		"filename": "/pa/units/land/energy_plant_adv/energy_plant_adv.papa",
-		"animations": {
-			"idle": "/pa/units/land/energy_plant_adv/energy_plant_adv_anim_work.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/constant_idle_anim_tree.json",
-		"skirt_decal": "/pa/effects/specs/skirt_energy_adv.json"
-	},
-	{
-		"layer": "WL_WaterSurface",
-		"filename": "/pa/units/sea/sea_energy_plant_adv/sea_energy_plant_adv.papa",
-		"animations": {
-			"idle": "/pa/units/land/energy_plant_adv/energy_plant_adv_anim_work.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/constant_idle_anim_tree.json"
-	}],
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/energy"
-		},
-		"died": {
-			"audio_cue": "/SE/Death/Factory",
-			"effect_scale": 1.25
-		}
-	},
-	"audio": {
-		"selection_response": {
-			"cue": "/SE/Selection/structure/energy"
-		}
-	},
-	"fx_offsets": [{
-		"type": "idle",
-		"filename": "/pa/units/land/energy_plant_adv/energy_plant_adv_idle.pfx",
-		"offset": [0,
-		0,
-		6.7]
-	}, {
-		"type": "idle",
-		"bone": "bone_root",
-		"filename": "/pa/effects/specs/stable_light_2.pfx",
-		"offset": [0, -7.66, 21.75]
-		},{
-		"type": "idle",
-		"bone": "bone_root",
-		"filename": "/pa/effects/specs/stable_light_2.pfx",
-		"offset": [-7.66, 0, 21.75]
-		},{
-		"type": "idle",
-		"bone": "bone_root",
-		"filename": "/pa/effects/specs/stable_light_2.pfx",
-		"offset": [7.66, 0, 21.75]
-		}
-	],
-	"headlights": [{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [7.25,
-		7.25,
-		8.0],
-		"orientation": [35.25,
-		-30.0,
-		125.25],
-		"near_width": 4.4,
-		"near_height": 4.4,
-		"near_distance": 2.0,
-		"far_distance": 25.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0
-	},
-	{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [7.25,
-		-7.25,
-		8.0],
-		"orientation": [35.25,
-		30.0,
-		54.75],
-		"near_width": 4.4,
-		"near_height": 4.4,
-		"near_distance": 2.0,
-		"far_distance": 25.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0
-	},
-	{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [-7.25,
-		-7.25,
-		8.0],
-		"orientation": [-35.25,
-		30.0,
-		-54.75],
-		"near_width": 4.4,
-		"near_height": 4.4,
-		"near_distance": 2.0,
-		"far_distance": 25.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0
-	},
-	{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [-7.25,
-		7.25,
-		8.0],
-		"orientation": [-35.25,
-		-30.0,
-		-125.25],
-		"near_width": 4.4,
-		"near_height": 4.4,
-		"near_distance": 2.0,
-		"far_distance": 25.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0
-	}],
-	"lamps": [{
-		"offset": [7.25,
-		7.25,
-		8.0],
-		"radius": 3.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [7.25,
-		-7.25,
-		8.0],
-		"radius": 3.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-7.25,
-		-7.25,
-		8.0],
-		"radius": 3.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-7.25,
-		7.25,
-		8.0],
-		"radius": 3.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [0.0,
-		-4.15,
-		2.3],
-		"radius": 4.5,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0,
-		"bone": "bone_rotor02"
-	},
-	{
-		"offset": [-3.59,
-		2.08,
-		2.3],
-		"radius": 4.5,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0,
-		"bone": "bone_rotor02"
-	},
-	{
-		"offset": [3.59,
-		2.08,
-		2.3],
-		"radius": 4.5,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0,
-		"bone": "bone_rotor02"
-	},
-	{
-		"offset": [0.0,
-		7.43,
-		22.97],
-		"radius": 4.0,
-		"color": [1.0,
-		0.0,
-		0.0],
-		"intensity": 2.0
-	}],
-	"mesh_bounds": [20,
-	20,
-	23.5],
-	"TEMP_texelinfo": 32.6108
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:advanced_energy_plant.message):Advanced Energy Plant",
+  "description": "!LOC(units:advanced_manufacturing_produces_energy.message):Advanced manufacturing- Produces energy.",
+  "max_health": 5000,
+  "build_metal_cost": 2700,
+  "atrophy_rate": 45.0,
+  "atrophy_cool_down": 15.0,
+  "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
+  "area_build_type": "Line",
+  "production": {
+    "energy": 5000
+  },
+  "unit_types": [
+    "UNITTYPE_Structure",
+    "UNITTYPE_EnergyProduction",
+    "UNITTYPE_Advanced",
+    "UNITTYPE_FabAdvBuild",
+    "UNITTYPE_Economy"
+  ],
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        }
+      ]
+    }
+  },
+  "model": [
+    {
+      "layer": "WL_LandHorizontal",
+      "filename": "/pa/units/land/energy_plant_adv/energy_plant_adv.papa",
+      "animations": {
+        "idle": "/pa/units/land/energy_plant_adv/energy_plant_adv_anim_work.papa"
+      },
+      "animtree": "/pa/anim/anim_trees/constant_idle_anim_tree.json",
+      "skirt_decal": "/pa/effects/specs/skirt_energy_adv.json"
+    },
+    {
+      "layer": "WL_WaterSurface",
+      "filename": "/pa/units/sea/sea_energy_plant_adv/sea_energy_plant_adv.papa",
+      "animations": {
+        "idle": "/pa/units/land/energy_plant_adv/energy_plant_adv_anim_work.papa"
+      },
+      "animtree": "/pa/anim/anim_trees/constant_idle_anim_tree.json"
+    }
+  ],
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/energy"
+    },
+    "died": {
+      "audio_cue": "/SE/Death/Factory",
+      "effect_scale": 1.25
+    }
+  },
+  "audio": {
+    "selection_response": {
+      "cue": "/SE/Selection/structure/energy"
+    }
+  },
+  "fx_offsets": [
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/energy_plant_adv/energy_plant_adv_idle.pfx",
+      "offset": [
+        0,
+        0,
+        6.7
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        0,
+        -7.66,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        -7.66,
+        0,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        7.66,
+        0,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        7.66,
+        0,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        -7.66,
+        0,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        0,
+        -7.66,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        0,
+        -7.66,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        -7.66,
+        0,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        7.66,
+        0,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        7.66,
+        0,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        -7.66,
+        0,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        0,
+        -7.66,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        0,
+        -7.66,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        -7.66,
+        0,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        7.66,
+        0,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        7.66,
+        0,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        -7.66,
+        0,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        0,
+        -7.66,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        0,
+        -7.66,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        -7.66,
+        0,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        7.66,
+        0,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        7.66,
+        0,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        -7.66,
+        0,
+        21.75
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        0,
+        -7.66,
+        21.75
+      ]
+    }
+  ],
+  "headlights": [
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        7.25,
+        7.25,
+        8.0
+      ],
+      "orientation": [
+        35.25,
+        -30.0,
+        125.25
+      ],
+      "near_width": 4.4,
+      "near_height": 4.4,
+      "near_distance": 2.0,
+      "far_distance": 25.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0
+    },
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        7.25,
+        -7.25,
+        8.0
+      ],
+      "orientation": [
+        35.25,
+        30.0,
+        54.75
+      ],
+      "near_width": 4.4,
+      "near_height": 4.4,
+      "near_distance": 2.0,
+      "far_distance": 25.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0
+    },
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        -7.25,
+        -7.25,
+        8.0
+      ],
+      "orientation": [
+        -35.25,
+        30.0,
+        -54.75
+      ],
+      "near_width": 4.4,
+      "near_height": 4.4,
+      "near_distance": 2.0,
+      "far_distance": 25.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0
+    },
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        -7.25,
+        7.25,
+        8.0
+      ],
+      "orientation": [
+        -35.25,
+        -30.0,
+        -125.25
+      ],
+      "near_width": 4.4,
+      "near_height": 4.4,
+      "near_distance": 2.0,
+      "far_distance": 25.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0
+    }
+  ],
+  "lamps": [
+    {
+      "offset": [
+        7.25,
+        7.25,
+        8.0
+      ],
+      "radius": 3.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        7.25,
+        -7.25,
+        8.0
+      ],
+      "radius": 3.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -7.25,
+        -7.25,
+        8.0
+      ],
+      "radius": 3.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -7.25,
+        7.25,
+        8.0
+      ],
+      "radius": 3.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        0.0,
+        -4.15,
+        2.3
+      ],
+      "radius": 4.5,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0,
+      "bone": "bone_rotor02"
+    },
+    {
+      "offset": [
+        -3.59,
+        2.08,
+        2.3
+      ],
+      "radius": 4.5,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0,
+      "bone": "bone_rotor02"
+    },
+    {
+      "offset": [
+        3.59,
+        2.08,
+        2.3
+      ],
+      "radius": 4.5,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0,
+      "bone": "bone_rotor02"
+    },
+    {
+      "offset": [
+        0.0,
+        7.43,
+        22.97
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "intensity": 2.0
+    }
+  ],
+  "mesh_bounds": [
+    20,
+    20,
+    23.5
+  ],
+  "TEMP_texelinfo": 32.6108
 }

--- a/pa/units/land/energy_storage/energy_storage.json
+++ b/pa/units/land/energy_storage/energy_storage.json
@@ -1,198 +1,274 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:energy_storage.message):Energy Storage",
-	"description": "!LOC(units:manufacturing_increases_maximum_energy_storage_capacity.message):Manufacturing- Increases maximum energy storage capacity.",
-	"max_health": 7500,
-	"build_metal_cost": 450,
-	"atrophy_rate": 7.5,
-	"atrophy_cool_down": 15.0,
-	"spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
-	"area_build_type": "Sphere",
-	"storage": {
-		"energy": 100000
-	},
-	"unit_types": ["UNITTYPE_Structure",
-	"UNITTYPE_Basic",
-	"UNITTYPE_CmdBuild",
-	"UNITTYPE_FabBuild",
-	"UNITTYPE_FabAdvBuild",
-	"UNITTYPE_Economy"],
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			}]
-		}
-	},
-	"model": [{
-		"layer": "WL_LandHorizontal",
-		"filename": "/pa/units/land/energy_storage/energy_storage.papa",
-		"skirt_decal": "/pa/effects/specs/skirt_energy_adv.json"
-	},
-	{
-		"layer": "WL_WaterSurface",
-		"filename": "/pa/units/sea/sea_energy_storage/sea_energy_storage.papa"
-	}],
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/energy"
-		},
-		"died": {
-			"audio_cue": "/SE/Death/Factory",
-			"effect_scale": 0.8
-		}
-	},
-	"audio": {
-		"selection_response": {
-			"cue": "/SE/Selection/structure/energy"
-		}
-	},
-		"fx_offsets": [{
-		"type": "idle",
-		"filename": "/pa/units/land/energy_storage/energy_storage.pfx",
-		"offset": [0,
-		0,
-		5]
-	},{
-			"type" : "idle",
-			"bone" : "bone_antenna01",
-			"filename" : "/pa/effects/specs/stable_light_2.pfx",
-			"offset" : [5.15, 5.15, 13]
-		},{
-			"type" : "idle",
-			"bone" : "bone_antenna01",
-			"filename" : "/pa/effects/specs/stable_light_2.pfx",
-			"offset" : [-5.15, -5.15, 13]
-		},{
-			"type" : "idle",
-			"bone" : "bone_antenna01",
-			"filename" : "/pa/effects/specs/stable_light_2.pfx",
-			"offset" : [-5.15, 5.15, 13]
-		},{
-			"type" : "idle",
-			"bone" : "bone_antenna01",
-			"filename" : "/pa/effects/specs/stable_light_2.pfx",
-			"offset" : [5.15, -5.15, 13]
-		}],
-	"headlights": [{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [6.2,
-		6.2,
-		8.6],
-		"orientation": [26.33,
-		-23.93,
-		-50.68],
-		"near_width": 5.5,
-		"near_height": 5.5,
-		"near_distance": 2.5,
-		"far_distance": 25.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0
-	},
-	{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [-6.2,
-		6.2,
-		8.6],
-		"orientation": [-26.34,
-		-23.93,
-		50.67],
-		"near_width": 5.5,
-		"near_height": 5.5,
-		"near_distance": 2.5,
-		"far_distance": 25.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0
-	},
-	{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [6.2,
-		-6.2,
-		8.6],
-		"orientation": [26.33,
-		23.92,
-		-129.32],
-		"near_width": 5.5,
-		"near_height": 5.5,
-		"near_distance": 2.5,
-		"far_distance": 25.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0
-	},
-	{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [-6.2,
-		-6.2,
-		8.6],
-		"orientation": [-26.34,
-		23.92,
-		129.31],
-		"near_width": 5.5,
-		"near_height": 5.5,
-		"near_distance": 2.5,
-		"far_distance": 25.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0
-	}],
-	"lamps": [{
-		"offset": [6.2,
-		6.2,
-		8.6],
-		"radius": 3.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0
-	},
-	{
-		"offset": [-6.2,
-		6.2,
-		8.6],
-		"radius": 3.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0
-	},
-	{
-		"offset": [6.2,
-		-6.2,
-		8.6],
-		"radius": 3.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0
-	},
-	{
-		"offset": [-6.2,
-		-6.2,
-		8.6],
-		"radius": 3.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0
-	}],
-	"mesh_bounds": [19,
-	20,
-	14.2],
-	"TEMP_texelinfo": 26.4567
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:energy_storage.message):Energy Storage",
+  "description": "!LOC(units:manufacturing_increases_maximum_energy_storage_capacity.message):Manufacturing- Increases maximum energy storage capacity.",
+  "max_health": 7500,
+  "build_metal_cost": 450,
+  "atrophy_rate": 7.5,
+  "atrophy_cool_down": 15.0,
+  "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
+  "area_build_type": "Sphere",
+  "storage": {
+    "energy": 100000
+  },
+  "unit_types": [
+    "UNITTYPE_Structure",
+    "UNITTYPE_Basic",
+    "UNITTYPE_CmdBuild",
+    "UNITTYPE_FabBuild",
+    "UNITTYPE_FabAdvBuild",
+    "UNITTYPE_Economy"
+  ],
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        }
+      ]
+    }
+  },
+  "model": [
+    {
+      "layer": "WL_LandHorizontal",
+      "filename": "/pa/units/land/energy_storage/energy_storage.papa",
+      "skirt_decal": "/pa/effects/specs/skirt_energy_adv.json"
+    },
+    {
+      "layer": "WL_WaterSurface",
+      "filename": "/pa/units/sea/sea_energy_storage/sea_energy_storage.papa"
+    }
+  ],
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/energy"
+    },
+    "died": {
+      "audio_cue": "/SE/Death/Factory",
+      "effect_scale": 0.8
+    }
+  },
+  "audio": {
+    "selection_response": {
+      "cue": "/SE/Selection/structure/energy"
+    }
+  },
+  "headlights": [
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        6.2,
+        6.2,
+        8.6
+      ],
+      "orientation": [
+        26.33,
+        -23.93,
+        -50.68
+      ],
+      "near_width": 5.5,
+      "near_height": 5.5,
+      "near_distance": 2.5,
+      "far_distance": 25.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0
+    },
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        -6.2,
+        6.2,
+        8.6
+      ],
+      "orientation": [
+        -26.34,
+        -23.93,
+        50.67
+      ],
+      "near_width": 5.5,
+      "near_height": 5.5,
+      "near_distance": 2.5,
+      "far_distance": 25.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0
+    },
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        6.2,
+        -6.2,
+        8.6
+      ],
+      "orientation": [
+        26.33,
+        23.92,
+        -129.32
+      ],
+      "near_width": 5.5,
+      "near_height": 5.5,
+      "near_distance": 2.5,
+      "far_distance": 25.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0
+    },
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        -6.2,
+        -6.2,
+        8.6
+      ],
+      "orientation": [
+        -26.34,
+        23.92,
+        129.31
+      ],
+      "near_width": 5.5,
+      "near_height": 5.5,
+      "near_distance": 2.5,
+      "far_distance": 25.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0
+    }
+  ],
+  "lamps": [
+    {
+      "offset": [
+        6.2,
+        6.2,
+        8.6
+      ],
+      "radius": 3.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0
+    },
+    {
+      "offset": [
+        -6.2,
+        6.2,
+        8.6
+      ],
+      "radius": 3.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0
+    },
+    {
+      "offset": [
+        6.2,
+        -6.2,
+        8.6
+      ],
+      "radius": 3.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0
+    },
+    {
+      "offset": [
+        -6.2,
+        -6.2,
+        8.6
+      ],
+      "radius": 3.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0
+    }
+  ],
+  "mesh_bounds": [
+    19,
+    20,
+    14.2
+  ],
+  "TEMP_texelinfo": 26.4567,
+  "fx_offsets": [
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/energy_storage/energy_storage.pfx",
+      "offset": [
+        0,
+        0,
+        5
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_antenna01",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        5.15,
+        5.15,
+        13
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_antenna01",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        -5.15,
+        -5.15,
+        13
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_antenna01",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        -5.15,
+        5.15,
+        13
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_antenna01",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        5.15,
+        -5.15,
+        13
+      ]
+    }
+  ]
 }

--- a/pa/units/land/laser_defense/laser_defense.json
+++ b/pa/units/land/laser_defense/laser_defense.json
@@ -1,80 +1,105 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:laser_defense_tower.message):Laser Defense Tower",
-	"description": "!LOC(units:basic_turret_equipped_with_direct_fire_anti_land_and_anti_ship_defenses.message):Basic turret- Equipped with direct fire anti-land, and anti-ship defenses.",
-	"max_health": 1500,
-	"build_metal_cost": 350,
-	"atrophy_rate": 7.5,
-	"atrophy_cool_down": 15.0,
-	"spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
-	"unit_types": ["UNITTYPE_Structure",
-	"UNITTYPE_Basic",
-	"UNITTYPE_Land",
-	"UNITTYPE_SurfaceDefense",
-	"UNITTYPE_Defense",
-	"UNITTYPE_FabBuild"],
-	"command_caps": ["ORDER_Attack"],
-	"guard_layer": "WL_AnySurface",
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 130
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 130
-			}]
-		}
-	},
-	"model": [{
-		"layer": "WL_LandHorizontal",
-		"filename": "/pa/units/land/laser_defense/laser_defense.papa",
-		"animtree": "/pa/anim/anim_trees/defense_turret_anim_tree.json",
-		"skirt_decal": "/pa/effects/specs/skirt_defense.json"
-	},
-	{
-		"layer": "WL_WaterSurface",
-		"filename": "/pa/units/sea/floating_laser/floating_laser.papa",
-		"animtree": "/pa/anim/anim_trees/defense_turret_anim_tree.json"
-	}],
-	"tools": [{
-		"spec_id": "/pa/units/land/laser_defense/laser_defense_tool_weapon.json",
-		"aim_bone": "bone_pitch",
-		"muzzle_bone": ["socket_rightMuzzle",
-		"socket_leftMuzzle"]
-	}],
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/structure_small"
-		},
-		"fired": {
-			"audio_cue": "/SE/Weapons/structure/laser_defense_double_fire",
-			"effect_spec": "/pa/effects/specs/default_muzzle_flash.pfx socket_rightMuzzle /pa/effects/specs/default_muzzle_flash.pfx socket_leftMuzzle"
-		},
-		"died": {
-			"audio_cue": "/SE/Death/structure_small",
-			"effect_scale": 0.6
-		}
-	},
-	"fx_offsets": [{
-		"type": "idle",
-		"bone": "bone_pitch",
-		"filename": "/pa/units/land/laser_defense/turret_lights.pfx",
-		"offset" : [2.05, -4.9, 0.2]
-	}, {
-		"type" : "idle",
-		"bone" : "bone_pitch",
-		"filename": "/pa/units/land/laser_defense/turret_lights.pfx",
-		"offset" : [-2.05, -4.9, 0.2]
-		}],
-	"mesh_bounds": [6,
-	6,
-	17.2],
-	"TEMP_texelinfo": 10.2184,
-	"area_build_separation": 18
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:laser_defense_tower.message):Laser Defense Tower",
+  "description": "!LOC(units:basic_turret_equipped_with_direct_fire_anti_land_and_anti_ship_defenses.message):Basic turret- Equipped with direct fire anti-land, and anti-ship defenses.",
+  "max_health": 1500,
+  "build_metal_cost": 350,
+  "atrophy_rate": 7.5,
+  "atrophy_cool_down": 15.0,
+  "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
+  "unit_types": [
+    "UNITTYPE_Structure",
+    "UNITTYPE_Basic",
+    "UNITTYPE_Land",
+    "UNITTYPE_SurfaceDefense",
+    "UNITTYPE_Defense",
+    "UNITTYPE_FabBuild"
+  ],
+  "command_caps": [
+    "ORDER_Attack"
+  ],
+  "guard_layer": "WL_AnySurface",
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 130
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 130
+        }
+      ]
+    }
+  },
+  "model": [
+    {
+      "layer": "WL_LandHorizontal",
+      "filename": "/pa/units/land/laser_defense/laser_defense.papa",
+      "animtree": "/pa/anim/anim_trees/defense_turret_anim_tree.json",
+      "skirt_decal": "/pa/effects/specs/skirt_defense.json"
+    },
+    {
+      "layer": "WL_WaterSurface",
+      "filename": "/pa/units/sea/floating_laser/floating_laser.papa",
+      "animtree": "/pa/anim/anim_trees/defense_turret_anim_tree.json"
+    }
+  ],
+  "tools": [
+    {
+      "spec_id": "/pa/units/land/laser_defense/laser_defense_tool_weapon.json",
+      "aim_bone": "bone_pitch",
+      "muzzle_bone": [
+        "socket_rightMuzzle",
+        "socket_leftMuzzle"
+      ]
+    }
+  ],
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/structure_small"
+    },
+    "fired": {
+      "audio_cue": "/SE/Weapons/structure/laser_defense_double_fire",
+      "effect_spec": "/pa/effects/specs/default_muzzle_flash.pfx socket_rightMuzzle /pa/effects/specs/default_muzzle_flash.pfx socket_leftMuzzle"
+    },
+    "died": {
+      "audio_cue": "/SE/Death/structure_small",
+      "effect_scale": 0.6
+    }
+  },
+  "mesh_bounds": [
+    6,
+    6,
+    17.2
+  ],
+  "TEMP_texelinfo": 10.2184,
+  "area_build_separation": 18,
+  "fx_offsets": [
+    {
+      "type": "idle",
+      "bone": "bone_pitch",
+      "filename": "/pa/units/land/laser_defense/turret_lights.pfx",
+      "offset": [
+        2.05,
+        -4.9,
+        0.2
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_pitch",
+      "filename": "/pa/units/land/laser_defense/turret_lights.pfx",
+      "offset": [
+        -2.05,
+        -4.9,
+        0.2
+      ]
+    }
+  ]
 }

--- a/pa/units/land/laser_defense_adv/laser_defense_adv.json
+++ b/pa/units/land/laser_defense_adv/laser_defense_adv.json
@@ -1,86 +1,116 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:advanced_laser_defense_tower.message):Advanced Laser Defense Tower",
-	"description": "!LOC(units:advanced_turret_equipped_with_direct_fire_anti_land_and_anti_ship_defenses.message):Advanced turret- Equipped with direct fire anti-land, and anti-ship defenses.",
-	"max_health": 4000,
-	"build_metal_cost": 900,
-	"atrophy_rate": 15.0,
-	"atrophy_cool_down": 15.0,
-	"spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
-	"unit_types": ["UNITTYPE_Structure",
-	"UNITTYPE_Advanced",
-	"UNITTYPE_Land",
-	"UNITTYPE_SurfaceDefense",
-	"UNITTYPE_Defense",
-	"UNITTYPE_FabAdvBuild"],
-	"command_caps": ["ORDER_Attack"],
-	"guard_layer": "WL_AnySurface",
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 130
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 130
-			}]
-		}
-	},
-	"model": [{
-		"layer": "WL_LandHorizontal",
-		"filename": "/pa/units/land/laser_defense_adv/laser_defense_adv.papa",
-		"animtree": "/pa/anim/anim_trees/defense_turret_adv_anim_tree.json",
-		"skirt_decal": "/pa/effects/specs/skirt_defense_adv.json"
-	},
-	{
-		"layer": "WL_WaterSurface",
-		"filename": "/pa/units/sea/floating_laser_adv/floating_laser_adv.papa",
-		"animtree": "/pa/anim/anim_trees/defense_turret_adv_anim_tree.json"
-	}],
-	"tools": [{
-		"spec_id": "/pa/units/land/laser_defense_adv/laser_defense_adv_tool_weapon.json",
-		"aim_bone": "bone_pitch",
-		"muzzle_bone": ["socket_rightMuzzle",
-		"socket_centerMuzzle",
-		"socket_leftMuzzle"]
-	}],
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/structure_small"
-		},
-		"fired": {
-			"audio_cue": "/SE/Weapons/structure/laser_defense_ADV_fire",
-			"effect_spec": "/pa/effects/specs/default_muzzle_flash.pfx socket_rightMuzzle /pa/effects/specs/default_muzzle_flash.pfx socket_centerMuzzle /pa/effects/specs/default_muzzle_flash.pfx socket_leftMuzzle"
-		},
-		"died": {
-			"audio_cue": "/SE/Death/structure_small",
-			"effect_scale": 0.75
-		}
-	},
-	"fx_offsets": [{
-		"type": "idle",
-		"bone": "bone_pitch",
-		"filename": "/pa/units/land/laser_defense_adv/turret_light_middle.pfx",
-		"offset" : [0, -5.4, 3.4]
-	}, {
-		"type" : "idle",
-		"bone" : "bone_pitch",
-		"filename": "/pa/units/land/laser_defense_adv/turret_lights.pfx",
-		"offset" : [-2.05, -4.15, 1.8]
-		}, {
-		"type" : "idle",
-		"bone" : "bone_pitch",
-		"filename": "/pa/units/land/laser_defense_adv/turret_lights.pfx",
-		"offset" : [2.05, -4.15, 1.8]
-		}],
-	"mesh_bounds": [8,
-	8,
-	23],
-	"area_build_separation": 18,
-	"TEMP_texelinfo": 15.3609
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:advanced_laser_defense_tower.message):Advanced Laser Defense Tower",
+  "description": "!LOC(units:advanced_turret_equipped_with_direct_fire_anti_land_and_anti_ship_defenses.message):Advanced turret- Equipped with direct fire anti-land, and anti-ship defenses.",
+  "max_health": 4000,
+  "build_metal_cost": 900,
+  "atrophy_rate": 15.0,
+  "atrophy_cool_down": 15.0,
+  "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
+  "unit_types": [
+    "UNITTYPE_Structure",
+    "UNITTYPE_Advanced",
+    "UNITTYPE_Land",
+    "UNITTYPE_SurfaceDefense",
+    "UNITTYPE_Defense",
+    "UNITTYPE_FabAdvBuild"
+  ],
+  "command_caps": [
+    "ORDER_Attack"
+  ],
+  "guard_layer": "WL_AnySurface",
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 130
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 130
+        }
+      ]
+    }
+  },
+  "model": [
+    {
+      "layer": "WL_LandHorizontal",
+      "filename": "/pa/units/land/laser_defense_adv/laser_defense_adv.papa",
+      "animtree": "/pa/anim/anim_trees/defense_turret_adv_anim_tree.json",
+      "skirt_decal": "/pa/effects/specs/skirt_defense_adv.json"
+    },
+    {
+      "layer": "WL_WaterSurface",
+      "filename": "/pa/units/sea/floating_laser_adv/floating_laser_adv.papa",
+      "animtree": "/pa/anim/anim_trees/defense_turret_adv_anim_tree.json"
+    }
+  ],
+  "tools": [
+    {
+      "spec_id": "/pa/units/land/laser_defense_adv/laser_defense_adv_tool_weapon.json",
+      "aim_bone": "bone_pitch",
+      "muzzle_bone": [
+        "socket_rightMuzzle",
+        "socket_centerMuzzle",
+        "socket_leftMuzzle"
+      ]
+    }
+  ],
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/structure_small"
+    },
+    "fired": {
+      "audio_cue": "/SE/Weapons/structure/laser_defense_ADV_fire",
+      "effect_spec": "/pa/effects/specs/default_muzzle_flash.pfx socket_rightMuzzle /pa/effects/specs/default_muzzle_flash.pfx socket_centerMuzzle /pa/effects/specs/default_muzzle_flash.pfx socket_leftMuzzle"
+    },
+    "died": {
+      "audio_cue": "/SE/Death/structure_small",
+      "effect_scale": 0.75
+    }
+  },
+  "mesh_bounds": [
+    8,
+    8,
+    23
+  ],
+  "area_build_separation": 18,
+  "TEMP_texelinfo": 15.3609,
+  "fx_offsets": [
+    {
+      "type": "idle",
+      "bone": "bone_pitch",
+      "filename": "/pa/units/land/laser_defense_adv/turret_light_middle.pfx",
+      "offset": [
+        0,
+        -5.4,
+        3.4
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_pitch",
+      "filename": "/pa/units/land/laser_defense_adv/turret_lights.pfx",
+      "offset": [
+        -2.05,
+        -4.15,
+        1.8
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_pitch",
+      "filename": "/pa/units/land/laser_defense_adv/turret_lights.pfx",
+      "offset": [
+        2.05,
+        -4.15,
+        1.8
+      ]
+    }
+  ]
 }

--- a/pa/units/land/laser_defense_single/laser_defense_single.json
+++ b/pa/units/land/laser_defense_single/laser_defense_single.json
@@ -1,76 +1,96 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:single_laser_defense_tower.message):Single Laser Defense Tower",
-	"description": "!LOC(units:basic_turret_equipped_with_direct_fire_anti_land_and_anti_ship_defenses.message):Basic turret- Equipped with direct fire anti-land, and anti-ship defenses.",
-	"max_health": 350,
-	"build_metal_cost": 225,
-	"atrophy_rate": 5.0,
-	"atrophy_cool_down": 15.0,
-	"spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
-	"unit_types": ["UNITTYPE_Structure",
-	"UNITTYPE_Basic",
-	"UNITTYPE_Land",
-	"UNITTYPE_SurfaceDefense",
-	"UNITTYPE_Defense",
-	"UNITTYPE_FabBuild",
-	"UNITTYPE_CmdBuild",
-	"UNITTYPE_CombatFabAdvBuild"],
-	"command_caps": ["ORDER_Attack"],
-	"guard_layer": "WL_AnyHorizontalGroundOrWaterSurface",
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 130
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 130
-			}]
-		}
-	},
-	"model": [{
-		"layer": "WL_LandHorizontal",
-		"filename": "/pa/units/land/laser_defense_single/laser_defense_single.papa",
-		"animtree": "/pa/anim/anim_trees/defense_turret_single_anim_tree.json",
-		"skirt_decal": "/pa/effects/specs/skirt_defense.json"
-	},
-	{
-		"layer": "WL_WaterSurface",
-		"filename": "/pa/units/sea/floating_laser_single/floating_laser_single.papa",
-		"animtree": "/pa/anim/anim_trees/defense_turret_single_anim_tree.json"
-	}],
-	"tools": [{
-		"spec_id": "/pa/units/land/laser_defense_single/laser_defense_single_tool_weapon.json",
-		"aim_bone": "bone_pitch",
-		"muzzle_bone": ["socket_muzzle"]
-	}],
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/structure_small"
-		},
-		"fired": {
-			"audio_cue": "/SE/Weapons/structure/laser_defense_single_fire",
-			"effect_spec": "/pa/effects/specs/default_muzzle_flash.pfx socket_muzzle"
-		},
-		"died": {
-			"audio_cue": "/SE/Death/structure_small",
-			"effect_scale": 0.55
-		}
-	},
-	"fx_offsets": [{
-		"type": "idle",
-		"bone": "bone_pitch",
-		"filename": "/pa/units/land/laser_defense_single/turret_lights.pfx",
-		"offset" : [-1.1, -3.625, 0.85]
-	}],
-	"mesh_bounds": [6.8,
-	5.76558,
-	14.6],
-	"area_build_separation": 18,
-	"TEMP_texelinfo": 10.2184
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:single_laser_defense_tower.message):Single Laser Defense Tower",
+  "description": "!LOC(units:basic_turret_equipped_with_direct_fire_anti_land_and_anti_ship_defenses.message):Basic turret- Equipped with direct fire anti-land, and anti-ship defenses.",
+  "max_health": 350,
+  "build_metal_cost": 225,
+  "atrophy_rate": 5.0,
+  "atrophy_cool_down": 15.0,
+  "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
+  "unit_types": [
+    "UNITTYPE_Structure",
+    "UNITTYPE_Basic",
+    "UNITTYPE_Land",
+    "UNITTYPE_SurfaceDefense",
+    "UNITTYPE_Defense",
+    "UNITTYPE_FabBuild",
+    "UNITTYPE_CmdBuild",
+    "UNITTYPE_CombatFabAdvBuild"
+  ],
+  "command_caps": [
+    "ORDER_Attack"
+  ],
+  "guard_layer": "WL_AnyHorizontalGroundOrWaterSurface",
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 130
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 130
+        }
+      ]
+    }
+  },
+  "model": [
+    {
+      "layer": "WL_LandHorizontal",
+      "filename": "/pa/units/land/laser_defense_single/laser_defense_single.papa",
+      "animtree": "/pa/anim/anim_trees/defense_turret_single_anim_tree.json",
+      "skirt_decal": "/pa/effects/specs/skirt_defense.json"
+    },
+    {
+      "layer": "WL_WaterSurface",
+      "filename": "/pa/units/sea/floating_laser_single/floating_laser_single.papa",
+      "animtree": "/pa/anim/anim_trees/defense_turret_single_anim_tree.json"
+    }
+  ],
+  "tools": [
+    {
+      "spec_id": "/pa/units/land/laser_defense_single/laser_defense_single_tool_weapon.json",
+      "aim_bone": "bone_pitch",
+      "muzzle_bone": [
+        "socket_muzzle"
+      ]
+    }
+  ],
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/structure_small"
+    },
+    "fired": {
+      "audio_cue": "/SE/Weapons/structure/laser_defense_single_fire",
+      "effect_spec": "/pa/effects/specs/default_muzzle_flash.pfx socket_muzzle"
+    },
+    "died": {
+      "audio_cue": "/SE/Death/structure_small",
+      "effect_scale": 0.55
+    }
+  },
+  "mesh_bounds": [
+    6.8,
+    5.76558,
+    14.6
+  ],
+  "area_build_separation": 18,
+  "TEMP_texelinfo": 10.2184,
+  "fx_offsets": [
+    {
+      "type": "idle",
+      "bone": "bone_pitch",
+      "filename": "/pa/units/land/laser_defense_single/turret_lights.pfx",
+      "offset": [
+        -1.1,
+        -3.625,
+        0.85
+      ]
+    }
+  ]
 }

--- a/pa/units/land/metal_extractor/metal_extractor.json
+++ b/pa/units/land/metal_extractor/metal_extractor.json
@@ -1,99 +1,128 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:metal_extractor.message):Metal Extractor",
-	"description": "!LOC(units:basic_manufacturing_produces_metal_can_only_be_placed_on_metal_deposits.message):Basic manufacturing- Produces metal, can only be placed on metal deposits.",
-	"max_health": 1000,
-	"build_metal_cost": 150,
-	"atrophy_rate": 2.5,
-	"atrophy_cool_down": 15.0,
-	"spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
-	"feature_requirements": ["metal_spot"],
-	"area_build_type": "Sphere",
-	"production": {
-		"metal": 7
-	},
-	"consumption": {
-		"energy": 0
-	},
-	"unit_types": ["UNITTYPE_Structure",
-	"UNITTYPE_Basic",
-	"UNITTYPE_MetalProduction",
-	"UNITTYPE_CmdBuild",
-	"UNITTYPE_FabBuild",
-	"UNITTYPE_Economy"],
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			}]
-		}
-	},
-	"model": [{
-		"layer": "WL_LandHorizontal",
-		"filename": "/pa/units/land/metal_extractor/metal_extractor.papa",
-		"animations": {
-			"idle": "/pa/units/land/metal_extractor/metal_extractor_anim_work.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/simple_building_anim_tree.json"
-	},
-	{
-		"layer": "WL_WaterSurface",
-		"filename": "/pa/units/sea/sea_metal_extractor/sea_metal_extractor.papa",
-		"animations": {
-			"idle": "/pa/units/sea/sea_metal_extractor/sea_metal_extractor_anim_work.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/simple_building_anim_tree.json"
-	}],
-	"replaceable_units": ["/pa/units/land/metal_extractor_adv/metal_extractor_adv.json"],
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/metal"
-		},
-		"died": {
-			"audio_cue": "/SE/Death/Factory",
-			"effect_scale": 0.75
-		}
-	},
-	"audio": {
-		"selection_response": {
-			"cue": "/SE/Selection/structure/metal"
-		}
-	},
-	"lamps": [{
-		"offset": [-0.72,
-		-1.922,
-		6.515],
-		"radius": 2.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0
-	}],
-	"fx_offsets": [{
-		"type": "idle",
-		"filename": "/pa/units/land/metal_extractor/metal_extractor_idle.pfx",
-		"offset": [0,
-		0,
-		5]
-	},{
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/land/metal_extractor/lightblink_2_2_2.pfx",
-			"offset" : [0, 0, 9.7]
-		}],
-	"mesh_bounds": [9.2,
-	10.0407,
-	23.5],
-	"placement_size": [20,
-	16],
-	"TEMP_texelinfo": 15.0973
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:metal_extractor.message):Metal Extractor",
+  "description": "!LOC(units:basic_manufacturing_produces_metal_can_only_be_placed_on_metal_deposits.message):Basic manufacturing- Produces metal, can only be placed on metal deposits.",
+  "max_health": 1000,
+  "build_metal_cost": 170,
+  "atrophy_rate": 2.5,
+  "atrophy_cool_down": 15.0,
+  "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
+  "feature_requirements": [
+    "metal_spot"
+  ],
+  "area_build_type": "Sphere",
+  "production": {
+    "metal": 7
+  },
+  "consumption": {
+    "energy": 0
+  },
+  "unit_types": [
+    "UNITTYPE_Structure",
+    "UNITTYPE_Basic",
+    "UNITTYPE_MetalProduction",
+    "UNITTYPE_CmdBuild",
+    "UNITTYPE_FabBuild",
+    "UNITTYPE_Economy"
+  ],
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        }
+      ]
+    }
+  },
+  "model": [
+    {
+      "layer": "WL_LandHorizontal",
+      "filename": "/pa/units/land/metal_extractor/metal_extractor.papa",
+      "animations": {
+        "idle": "/pa/units/land/metal_extractor/metal_extractor_anim_work.papa"
+      },
+      "animtree": "/pa/anim/anim_trees/simple_building_anim_tree.json"
+    },
+    {
+      "layer": "WL_WaterSurface",
+      "filename": "/pa/units/sea/sea_metal_extractor/sea_metal_extractor.papa",
+      "animations": {
+        "idle": "/pa/units/sea/sea_metal_extractor/sea_metal_extractor_anim_work.papa"
+      },
+      "animtree": "/pa/anim/anim_trees/simple_building_anim_tree.json"
+    }
+  ],
+  "replaceable_units": [
+    "/pa/units/land/metal_extractor_adv/metal_extractor_adv.json"
+  ],
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/metal"
+    },
+    "died": {
+      "audio_cue": "/SE/Death/Factory",
+      "effect_scale": 0.75
+    }
+  },
+  "audio": {
+    "selection_response": {
+      "cue": "/SE/Selection/structure/metal"
+    }
+  },
+  "lamps": [
+    {
+      "offset": [
+        -0.72,
+        -1.922,
+        6.515
+      ],
+      "radius": 2.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0
+    }
+  ],
+  "mesh_bounds": [
+    9.2,
+    10.0407,
+    23.5
+  ],
+  "placement_size": [
+    20,
+    16
+  ],
+  "TEMP_texelinfo": 15.0973,
+  "fx_offsets": [
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/metal_extractor/metal_extractor_idle.pfx",
+      "offset": [
+        0,
+        0,
+        5
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/metal_extractor/lightblink_2_2_2.pfx",
+      "offset": [
+        0,
+        0,
+        9.7
+      ]
+    }
+  ]
 }

--- a/pa/units/land/metal_extractor_adv/metal_extractor_adv.json
+++ b/pa/units/land/metal_extractor_adv/metal_extractor_adv.json
@@ -1,96 +1,120 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:advanced_metal_extractor.message):Advanced Metal Extractor",
-	"description": "!LOC(units:advanced_manufacturing_produces_metal_can_only_be_placed_on_metal_deposits.message):Advanced manufacturing- Produces metal, can only be placed on metal deposits.",
-	"strategic_icon_priority": 5,
-	"max_health": 5000,
-	"build_metal_cost": 2000,
-	"atrophy_rate": 33.3333,
-	"atrophy_cool_down": 15.0,
-	"spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
-	"feature_requirements": ["metal_spot"],
-	"area_build_type": "Sphere",
-	"production": {
-		"metal": 24
-	},
-	"consumption": {
-		"energy": 0
-	},
-	"unit_types": ["UNITTYPE_Structure",
-	"UNITTYPE_Advanced",
-	"UNITTYPE_MetalProduction",
-	"UNITTYPE_FabAdvBuild",
-	"UNITTYPE_Economy"],
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			}]
-		}
-	},
-	"model": [{
-		"layer": "WL_LandHorizontal",
-		"filename": "/pa/units/land/metal_extractor_adv/metal_extractor_adv.papa",
-		"animations": {
-			"idle": "/pa/units/land/metal_extractor_adv/metal_extractor_adv_anim_work.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/constant_idle_anim_tree.json",
-		"arrows": 10
-	},
-	{
-		"layer": "WL_WaterSurface",
-		"filename": "/pa/units/sea/sea_metal_extractor_adv/sea_metal_extractor_adv.papa",
-		"animations": {
-			"idle": "/pa/units/sea/sea_metal_extractor_adv/sea_metal_extractor_adv_anim_work.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/constant_idle_anim_tree.json",
-		"arrows": 10
-	}],
-	"replaceable_units": ["/pa/units/land/metal_extractor/metal_extractor.json"],
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/metal"
-		},
-		"died": {
-			"audio_cue": "/SE/Death/Factory",
-			"effect_scale": 0.8
-		}
-	},
-	"audio": {
-		"selection_response": {
-			"cue": "/SE/Selection/structure/metal"
-		}
-	},
-	"lamps": [{
-		"offset": [0.0,
-		-2.273,
-		8.746],
-		"radius": 5.0,
-		"color": [1.0,
-		0.0,
-		0.0],
-		"intensity": 1.0
-	}],
-		"fx_offsets": [{
-		"type": "idle",
-		"filename": "/pa/units/land/metal_extractor_adv/metal_extractor_adv.pfx",
-		"offset": [0,
-		0,
-		5]
-	}],
-	"mesh_bounds": [15.5,
-	13.3685,
-	23.2],
-	"placement_size": [20,
-	16],
-	"TEMP_texelinfo": 24.4307
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:advanced_metal_extractor.message):Advanced Metal Extractor",
+  "description": "!LOC(units:advanced_manufacturing_produces_metal_can_only_be_placed_on_metal_deposits.message):Advanced manufacturing- Produces metal, can only be placed on metal deposits.",
+  "strategic_icon_priority": 5,
+  "max_health": 5000,
+  "build_metal_cost": 2000,
+  "atrophy_rate": 33.3333,
+  "atrophy_cool_down": 15.0,
+  "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
+  "feature_requirements": [
+    "metal_spot"
+  ],
+  "area_build_type": "Sphere",
+  "production": {
+    "metal": 24
+  },
+  "consumption": {
+    "energy": 0
+  },
+  "unit_types": [
+    "UNITTYPE_Structure",
+    "UNITTYPE_Advanced",
+    "UNITTYPE_MetalProduction",
+    "UNITTYPE_FabAdvBuild",
+    "UNITTYPE_Economy"
+  ],
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        }
+      ]
+    }
+  },
+  "model": [
+    {
+      "layer": "WL_LandHorizontal",
+      "filename": "/pa/units/land/metal_extractor_adv/metal_extractor_adv.papa",
+      "animations": {
+        "idle": "/pa/units/land/metal_extractor_adv/metal_extractor_adv_anim_work.papa"
+      },
+      "animtree": "/pa/anim/anim_trees/constant_idle_anim_tree.json",
+      "arrows": 10
+    },
+    {
+      "layer": "WL_WaterSurface",
+      "filename": "/pa/units/sea/sea_metal_extractor_adv/sea_metal_extractor_adv.papa",
+      "animations": {
+        "idle": "/pa/units/sea/sea_metal_extractor_adv/sea_metal_extractor_adv_anim_work.papa"
+      },
+      "animtree": "/pa/anim/anim_trees/constant_idle_anim_tree.json",
+      "arrows": 10
+    }
+  ],
+  "replaceable_units": [
+    "/pa/units/land/metal_extractor/metal_extractor.json"
+  ],
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/metal"
+    },
+    "died": {
+      "audio_cue": "/SE/Death/Factory",
+      "effect_scale": 0.8
+    }
+  },
+  "audio": {
+    "selection_response": {
+      "cue": "/SE/Selection/structure/metal"
+    }
+  },
+  "lamps": [
+    {
+      "offset": [
+        0.0,
+        -2.273,
+        8.746
+      ],
+      "radius": 5.0,
+      "color": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "intensity": 1.0
+    }
+  ],
+  "mesh_bounds": [
+    15.5,
+    13.3685,
+    23.2
+  ],
+  "placement_size": [
+    20,
+    16
+  ],
+  "TEMP_texelinfo": 24.4307,
+  "fx_offsets": [
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/metal_extractor_adv/metal_extractor_adv.pfx",
+      "offset": [
+        0,
+        0,
+        5
+      ]
+    }
+  ]
 }

--- a/pa/units/land/metal_storage/metal_storage.json
+++ b/pa/units/land/metal_storage/metal_storage.json
@@ -1,128 +1,171 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:metal_storage.message):Metal Storage",
-	"description": "!LOC(units:manufacturing_increases_maximum_metal_storage_capacity.message):Manufacturing- Increases maximum metal storage capacity.",
-	"max_health": 7500,
-	"build_metal_cost": 450,
-	"atrophy_rate": 7.5,
-	"atrophy_cool_down": 15.0,
-	"spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
-	"area_build_type": "Sphere",
-	"storage": {
-		"metal": 20000
-	},
-	"unit_types": ["UNITTYPE_Structure",
-	"UNITTYPE_Basic",
-	"UNITTYPE_CmdBuild",
-	"UNITTYPE_FabBuild",
-	"UNITTYPE_FabAdvBuild",
-	"UNITTYPE_Economy"],
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			}]
-		}
-	},
-	"model": [{
-		"layer": "WL_LandHorizontal",
-		"filename": "/pa/units/land/metal_storage/metal_storage.papa",
-		"skirt_decal": "/pa/effects/specs/skirt_metal.json"
-	},
-	{
-		"layer": "WL_WaterSurface",
-		"filename": "/pa/units/sea/sea_metal_storage/sea_metal_storage.papa"
-	}],
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/metal"
-		},
-		"died": {
-			"audio_cue": "/SE/Death/Factory",
-			"effect_scale": 0.8
-		}
-	},
-	"audio": {
-		"selection_response": {
-			"cue": "/SE/Selection/structure/metal"
-		}
-	},
-			"fx_offsets": [{
-			"type": "idle",
-			"filename": "/pa/units/land/metal_storage/metal_storage.pfx",
-			"offset": [0,
-		0,
-		5]
-		},{
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/effects/specs/stable_light_2.pfx",
-			"offset" : [-2.5, 8.157, 12.7]
-		},{
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/effects/specs/stable_light_2.pfx",
-			"offset" : [2.5, 8.157, 12.7]
-		}		
-	],
-	"headlights": [{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [0.0,
-		-9.63,
-		13.0],
-		"orientation": [0.0,
-		23.0,
-		0.0],
-		"near_width": 8,
-		"near_height": 8,
-		"near_distance": 5.0,
-		"far_distance": 25.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0
-	}],
-	"lamps": [{
-		"offset": [2.5,
-		9.59,
-		8.54],
-		"radius": 11.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0
-	},
-	{
-		"offset": [-2.5,
-		9.59,
-		8.54],
-		"radius": 11.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0
-	},
-	{
-		"offset": [0.0,
-		-9.63,
-		13.0],
-		"radius": 4.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 3.0
-	}],
-	"mesh_bounds": [18,
-	18,
-	17.151],
-	"TEMP_texelinfo": 21.4256
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:metal_storage.message):Metal Storage",
+  "description": "!LOC(units:manufacturing_increases_maximum_metal_storage_capacity.message):Manufacturing- Increases maximum metal storage capacity.",
+  "max_health": 7500,
+  "build_metal_cost": 450,
+  "atrophy_rate": 7.5,
+  "atrophy_cool_down": 15.0,
+  "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
+  "area_build_type": "Sphere",
+  "storage": {
+    "metal": 20000
+  },
+  "unit_types": [
+    "UNITTYPE_Structure",
+    "UNITTYPE_Basic",
+    "UNITTYPE_CmdBuild",
+    "UNITTYPE_FabBuild",
+    "UNITTYPE_FabAdvBuild",
+    "UNITTYPE_Economy"
+  ],
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        }
+      ]
+    }
+  },
+  "model": [
+    {
+      "layer": "WL_LandHorizontal",
+      "filename": "/pa/units/land/metal_storage/metal_storage.papa",
+      "skirt_decal": "/pa/effects/specs/skirt_metal.json"
+    },
+    {
+      "layer": "WL_WaterSurface",
+      "filename": "/pa/units/sea/sea_metal_storage/sea_metal_storage.papa"
+    }
+  ],
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/metal"
+    },
+    "died": {
+      "audio_cue": "/SE/Death/Factory",
+      "effect_scale": 0.8
+    }
+  },
+  "audio": {
+    "selection_response": {
+      "cue": "/SE/Selection/structure/metal"
+    }
+  },
+  "headlights": [
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        0.0,
+        -9.63,
+        13.0
+      ],
+      "orientation": [
+        0.0,
+        23.0,
+        0.0
+      ],
+      "near_width": 8,
+      "near_height": 8,
+      "near_distance": 5.0,
+      "far_distance": 25.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0
+    }
+  ],
+  "lamps": [
+    {
+      "offset": [
+        2.5,
+        9.59,
+        8.54
+      ],
+      "radius": 11.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0
+    },
+    {
+      "offset": [
+        -2.5,
+        9.59,
+        8.54
+      ],
+      "radius": 11.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0
+    },
+    {
+      "offset": [
+        0.0,
+        -9.63,
+        13.0
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 3.0
+    }
+  ],
+  "mesh_bounds": [
+    18,
+    18,
+    17.151
+  ],
+  "TEMP_texelinfo": 21.4256,
+  "fx_offsets": [
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/metal_storage/metal_storage.pfx",
+      "offset": [
+        0,
+        0,
+        5
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        -2.5,
+        8.157,
+        12.7
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "offset": [
+        2.5,
+        8.157,
+        12.7
+      ]
+    }
+  ]
 }

--- a/pa/units/land/nuke_launcher/nuke_launcher.json
+++ b/pa/units/land/nuke_launcher/nuke_launcher.json
@@ -1,189 +1,404 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:nuclear_missile_launcher.message):Nuclear Missile Launcher",
-	"description": "!LOC(units:nuclear_missile_launcher_equipped_with_advanced_long_range_large_area_damage_nuclear_missile.message):Nuclear missile launcher- Equipped with advanced long range, large area damage, nuclear missile.",
-	"max_health": 1500,
-	"build_metal_cost": 14400,
-	"atrophy_rate": 240.0,
-	"atrophy_cool_down": 15.0,
-	"spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
-	"buildable_projectiles": ["/pa/units/land/nuke_launcher/nuke_launcher_ammo.json"],
-	"factory": {
-		"store_units": true,
-		"spawn_points": ["bone_missile01"],
-		"initial_build_spec": "/pa/units/land/nuke_launcher/nuke_launcher_ammo.json",
-		"default_build_stance": "Continuous"
-	},
-	"unit_types": ["UNITTYPE_Land",
-	"UNITTYPE_Structure",
-	"UNITTYPE_Offense",
-	"UNITTYPE_Advanced",
-	"UNITTYPE_Nuke",
-	"UNITTYPE_Factory",
-	"UNITTYPE_FabAdvBuild",
-	"UNITTYPE_Important"],
-	"command_caps": ["ORDER_FactoryBuild",
-	"ORDER_Attack"],
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			}]
-		}
-	},
-	"model": [{
-		"layer": "WL_LandHorizontal",
-		"filename": "/pa/units/land/nuke_launcher/nuke_launcher.papa",
-		"animations": {
-			"build_start": "/pa/units/land/nuke_launcher/nuke_launcher_anim_buildStart.papa",
-			"build_loop": "/pa/units/land/nuke_launcher/nuke_launcher_anim_buildLoop.papa",
-			"build_end": "/pa/units/land/nuke_launcher/nuke_launcher_anim_buildEnd.papa",
-			"fire_start": "/pa/units/land/nuke_launcher/nuke_launcher_anim_fireStart.papa",
-			"fire_loop": "/pa/units/land/nuke_launcher/nuke_launcher_anim_fireLoop.papa",
-			"fire_end": "/pa/units/land/nuke_launcher/nuke_launcher_anim_fireEnd.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/missile_launcher_anim_tree.json",
-		"skirt_decal": "/pa/effects/specs/skirt_nuke.json"
-	},
-	{
-		"layer": "WL_WaterSurface",
-		"filename": "/pa/units/sea/nuke_launcher/nuke_launcher.papa",
-		"animations": {
-			"build_start": "/pa/units/land/nuke_launcher/nuke_launcher_anim_buildStart.papa",
-			"build_loop": "/pa/units/land/nuke_launcher/nuke_launcher_anim_buildLoop.papa",
-			"build_end": "/pa/units/land/nuke_launcher/nuke_launcher_anim_buildEnd.papa",
-			"fire_start": "/pa/units/land/nuke_launcher/nuke_launcher_anim_fireStart.papa",
-			"fire_loop": "/pa/units/land/nuke_launcher/nuke_launcher_anim_fireLoop.papa",
-			"fire_end": "/pa/units/land/nuke_launcher/nuke_launcher_anim_fireEnd.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/missile_launcher_anim_tree.json"
-	}],
-	"tools": [{
-		"spec_id": "/pa/units/land/nuke_launcher/nuke_launcher_tool_weapon.json",
-		"aim_bone": "bone_root"
-	},
-	{
-		"spec_id": "/pa/units/land/nuke_launcher/nuke_launcher_build_arm.json",
-		"aim_bone": "bone_root"
-	}],
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/factory"
-		},
-		"fired": {
-			"audio_cue": "/SE/Weapons/structure/nuke_launcher_fire",
-			"effect_spec": "/pa/units/land/nuke_launcher/nuke_launcher_launch.pfx"
-		},
-		"died": {
-			"audio_cue": "/SE/Death/Factory"
-		}
-	},
-	"audio": {
-		"loops": {
-			"build": {
-				"cue": "/SE/Construction/Factory_contruction_loop_nuke",
-				"flag": "build_target_changed",
-				"should_start_func": "has_build_target",
-				"should_stop_func": "no_build_target"
-			}
-		},
-		"selection_response": {
-			"cue": "/SE/Selection/structure/nuke"
-		}
-	},
-	"fx_offsets" : [{
-			"type" : "build",
-			"filename" : "/pa/effects/specs/fab_spray.pfx",
-			"bone" : "socket_muzzle01",
-			"offset" : [0, 0, 0],
-			"orientation" : [0, 0, 0]
-		},{
-			"label" : "Big Antenna",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/effects/specs/light_2_4_2_2.pfx",
-			"offset" : [0, 5.2, 23.5]
-		},{
-			"label" : "Little Antenna",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/effects/specs/light_2_4_1_2.pfx",
-			"offset" : [0, 4.3, 21.85]
-		}
-	],
-	"lamps": [{
-		"offset": [0.06,
-		1.06,
-		-0.01],
-		"radius": 2.0,
-		"color": [0.1,
-		1.0,
-		0.1],
-		"intensity": 2.0,
-		"bone": "bone_armBase"
-	},
-	{
-		"offset": [-2.36,
-		0.0,
-		-1.78],
-		"radius": 4.0,
-		"color": [0.1,
-		1.0,
-		0.1],
-		"intensity": 2.0,
-		"bone": "bone_armElbow"
-	},
-	{
-		"offset": [2.8,
-		2.8,
-		5.6],
-		"radius": 3.5,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 5.0
-	},
-	{
-		"offset": [2.8,
-		-2.8,
-		5.6],
-		"radius": 3.5,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 5.0
-	},
-	{
-		"offset": [-2.8,
-		2.8,
-		5.6],
-		"radius": 3.5,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 5.0
-	},
-	{
-		"offset": [-2.8,
-		-2.8,
-		5.6],
-		"radius": 3.5,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 5.0
-	}],
-	"mesh_bounds": [14,
-	14,
-	18],
-	"TEMP_texelinfo": 19.5004
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:nuclear_missile_launcher.message):Nuclear Missile Launcher",
+  "description": "!LOC(units:nuclear_missile_launcher_equipped_with_advanced_long_range_large_area_damage_nuclear_missile.message):Nuclear missile launcher- Equipped with advanced long range, large area damage, nuclear missile.",
+  "max_health": 1500,
+  "build_metal_cost": 14400,
+  "atrophy_rate": 240.0,
+  "atrophy_cool_down": 15.0,
+  "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
+  "buildable_projectiles": [
+    "/pa/units/land/nuke_launcher/nuke_launcher_ammo.json"
+  ],
+  "factory": {
+    "store_units": true,
+    "spawn_points": [
+      "bone_missile01"
+    ],
+    "initial_build_spec": "/pa/units/land/nuke_launcher/nuke_launcher_ammo.json",
+    "default_build_stance": "Continuous"
+  },
+  "unit_types": [
+    "UNITTYPE_Land",
+    "UNITTYPE_Structure",
+    "UNITTYPE_Offense",
+    "UNITTYPE_Advanced",
+    "UNITTYPE_Nuke",
+    "UNITTYPE_Factory",
+    "UNITTYPE_FabAdvBuild",
+    "UNITTYPE_Important"
+  ],
+  "command_caps": [
+    "ORDER_FactoryBuild",
+    "ORDER_Attack"
+  ],
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        }
+      ]
+    }
+  },
+  "model": [
+    {
+      "layer": "WL_LandHorizontal",
+      "filename": "/pa/units/land/nuke_launcher/nuke_launcher.papa",
+      "animations": {
+        "build_start": "/pa/units/land/nuke_launcher/nuke_launcher_anim_buildStart.papa",
+        "build_loop": "/pa/units/land/nuke_launcher/nuke_launcher_anim_buildLoop.papa",
+        "build_end": "/pa/units/land/nuke_launcher/nuke_launcher_anim_buildEnd.papa",
+        "fire_start": "/pa/units/land/nuke_launcher/nuke_launcher_anim_fireStart.papa",
+        "fire_loop": "/pa/units/land/nuke_launcher/nuke_launcher_anim_fireLoop.papa",
+        "fire_end": "/pa/units/land/nuke_launcher/nuke_launcher_anim_fireEnd.papa"
+      },
+      "animtree": "/pa/anim/anim_trees/missile_launcher_anim_tree.json",
+      "skirt_decal": "/pa/effects/specs/skirt_nuke.json"
+    },
+    {
+      "layer": "WL_WaterSurface",
+      "filename": "/pa/units/sea/nuke_launcher/nuke_launcher.papa",
+      "animations": {
+        "build_start": "/pa/units/land/nuke_launcher/nuke_launcher_anim_buildStart.papa",
+        "build_loop": "/pa/units/land/nuke_launcher/nuke_launcher_anim_buildLoop.papa",
+        "build_end": "/pa/units/land/nuke_launcher/nuke_launcher_anim_buildEnd.papa",
+        "fire_start": "/pa/units/land/nuke_launcher/nuke_launcher_anim_fireStart.papa",
+        "fire_loop": "/pa/units/land/nuke_launcher/nuke_launcher_anim_fireLoop.papa",
+        "fire_end": "/pa/units/land/nuke_launcher/nuke_launcher_anim_fireEnd.papa"
+      },
+      "animtree": "/pa/anim/anim_trees/missile_launcher_anim_tree.json"
+    }
+  ],
+  "tools": [
+    {
+      "spec_id": "/pa/units/land/nuke_launcher/nuke_launcher_tool_weapon.json",
+      "aim_bone": "bone_root"
+    },
+    {
+      "spec_id": "/pa/units/land/nuke_launcher/nuke_launcher_build_arm.json",
+      "aim_bone": "bone_root"
+    }
+  ],
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/factory"
+    },
+    "fired": {
+      "audio_cue": "/SE/Weapons/structure/nuke_launcher_fire",
+      "effect_spec": "/pa/units/land/nuke_launcher/nuke_launcher_launch.pfx"
+    },
+    "died": {
+      "audio_cue": "/SE/Death/Factory"
+    }
+  },
+  "audio": {
+    "loops": {
+      "build": {
+        "cue": "/SE/Construction/Factory_contruction_loop_nuke",
+        "flag": "build_target_changed",
+        "should_start_func": "has_build_target",
+        "should_stop_func": "no_build_target"
+      }
+    },
+    "selection_response": {
+      "cue": "/SE/Selection/structure/nuke"
+    }
+  },
+  "fx_offsets": [
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_muzzle01",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "label": "Big Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        0,
+        5.2,
+        23.5
+      ]
+    },
+    {
+      "label": "Little Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        0,
+        4.3,
+        21.85
+      ]
+    },
+    {
+      "label": "Little Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        0,
+        4.3,
+        21.85
+      ]
+    },
+    {
+      "label": "Big Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        0,
+        5.2,
+        23.5
+      ]
+    },
+    {
+      "label": "Big Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        0,
+        5.2,
+        23.5
+      ]
+    },
+    {
+      "label": "Little Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        0,
+        4.3,
+        21.85
+      ]
+    },
+    {
+      "label": "Little Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        0,
+        4.3,
+        21.85
+      ]
+    },
+    {
+      "label": "Big Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        0,
+        5.2,
+        23.5
+      ]
+    },
+    {
+      "label": "Big Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        0,
+        5.2,
+        23.5
+      ]
+    },
+    {
+      "label": "Little Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        0,
+        4.3,
+        21.85
+      ]
+    },
+    {
+      "label": "Little Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        0,
+        4.3,
+        21.85
+      ]
+    },
+    {
+      "label": "Big Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        0,
+        5.2,
+        23.5
+      ]
+    },
+    {
+      "label": "Big Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        0,
+        5.2,
+        23.5
+      ]
+    },
+    {
+      "label": "Little Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        0,
+        4.3,
+        21.85
+      ]
+    },
+    {
+      "label": "Little Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        0,
+        4.3,
+        21.85
+      ]
+    },
+    {
+      "label": "Big Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        0,
+        5.2,
+        23.5
+      ]
+    }
+  ],
+  "lamps": [
+    {
+      "offset": [
+        0.06,
+        1.06,
+        -0.01
+      ],
+      "radius": 2.0,
+      "color": [
+        0.1,
+        1.0,
+        0.1
+      ],
+      "intensity": 2.0,
+      "bone": "bone_armBase"
+    },
+    {
+      "offset": [
+        -2.36,
+        0.0,
+        -1.78
+      ],
+      "radius": 4.0,
+      "color": [
+        0.1,
+        1.0,
+        0.1
+      ],
+      "intensity": 2.0,
+      "bone": "bone_armElbow"
+    },
+    {
+      "offset": [
+        2.8,
+        2.8,
+        5.6
+      ],
+      "radius": 3.5,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 5.0
+    },
+    {
+      "offset": [
+        2.8,
+        -2.8,
+        5.6
+      ],
+      "radius": 3.5,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 5.0
+    },
+    {
+      "offset": [
+        -2.8,
+        2.8,
+        5.6
+      ],
+      "radius": 3.5,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 5.0
+    },
+    {
+      "offset": [
+        -2.8,
+        -2.8,
+        5.6
+      ],
+      "radius": 3.5,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 5.0
+    }
+  ],
+  "mesh_bounds": [
+    14,
+    14,
+    18
+  ],
+  "TEMP_texelinfo": 19.5004
 }

--- a/pa/units/land/tactical_missile_launcher/tactical_missile_launcher.json
+++ b/pa/units/land/tactical_missile_launcher/tactical_missile_launcher.json
@@ -1,96 +1,119 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:catapult.message):Catapult",
-	"description": "!LOC(units:tactical_missile_launcher_equipped_with_advanced_long_range_anti_land_missile_launcher.message):Tactical missile launcher- Equipped with advanced long range anti-land missile launcher.",
-	"max_health": 1500,
-	"build_metal_cost": 1800,
-	"atrophy_rate": 30.0,
-	"atrophy_cool_down": 15.0,
-	"spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
-	"unit_types": ["UNITTYPE_Land",
-	"UNITTYPE_Structure",
-	"UNITTYPE_Tactical",
-	"UNITTYPE_Defense",
-	"UNITTYPE_Advanced",
-	"UNITTYPE_FabAdvBuild",
-	"UNITTYPE_Important"],
-	"command_caps": ["ORDER_Attack"],
-	"guard_layer": "WL_AnySurface",
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			}]
-		}
-	},
-	"model": [{
-		"layer": "WL_LandHorizontal",
-		"filename": "/pa/units/land/tactical_missile_launcher/tactical_missile_launcher.papa",
-		"animations": {
-			"start": "/pa/units/land/tactical_missile_launcher/tactical_missile_launcher_anim_start.papa",
-			"end": "/pa/units/land/tactical_missile_launcher/tactical_missile_launcher_anim_end.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/tactical_missile_launcher_anim_tree.json",
-		"skirt_decal": "/pa/effects/specs/skirt_08.json"
-	},
-	{
-		"layer": "WL_WaterSurface",
-		"filename": "/pa/units/sea/tactical_missile_launcher/tactical_missile_launcher.papa",
-		"animations": {
-			"start": "/pa/units/land/tactical_missile_launcher/tactical_missile_launcher_anim_start.papa",
-			"end": "/pa/units/land/tactical_missile_launcher/tactical_missile_launcher_anim_end.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/tactical_missile_launcher_anim_tree.json"
-	}],
-	"tools": [{
-		"spec_id": "/pa/units/land/tactical_missile_launcher/tactical_missile_launcher_tool_weapon.json",
-		"aim_bone": "bone_missile01",
-		"muzzle_bone": "bone_missile01"
-	},
-	{
-		"spec_id": "/pa/units/land/tactical_missile_launcher/tactical_missile_tool_antidrop.json",
-		"aim_bone": "bone_missile01",
-		"muzzle_bone": "bone_missile01"
-	}],
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/factory"
-		},
-		"fired": {
-			"audio_cue": "/SE/Weapons/structure/tact_mis_launcher_catapult_fire",
-			"effect_spec": "/pa/units/land/tactical_missile_launcher/tactical_missile_launcher_launch.pfx"
-		},
-		"died": {
-			"audio_cue": "/SE/Death/Factory",
-			"effect_scale": 0.5
-		}
-	},
-	"audio": {
-		"selection_response": {
-			"cue": "/SE/Selection/structure/artillery"
-		}
-	},
-		"fx_offsets": [{
-		"type": "idle",
-			"filename" : "/pa/units/land/tactical_missile_launcher/light_2_3_3.pfx",
-			"offset" : [3.9, 0.6, 8.8]
-	},{
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/land/tactical_missile_launcher/light_2_3_1.pfx",
-			"offset" : [-3.9, -0.6, 8.8]
-		}],
-	"TEMP_texelinfo": 15.8261,
-	"mesh_bounds": [9,
-	9,
-	8.7]
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:catapult.message):Catapult",
+  "description": "!LOC(units:tactical_missile_launcher_equipped_with_advanced_long_range_anti_land_missile_launcher.message):Tactical missile launcher- Equipped with advanced long range anti-land missile launcher.",
+  "max_health": 1500,
+  "build_metal_cost": 1800,
+  "atrophy_rate": 30.0,
+  "atrophy_cool_down": 15.0,
+  "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
+  "unit_types": [
+    "UNITTYPE_Land",
+    "UNITTYPE_Structure",
+    "UNITTYPE_Tactical",
+    "UNITTYPE_Defense",
+    "UNITTYPE_Advanced",
+    "UNITTYPE_FabAdvBuild",
+    "UNITTYPE_Important"
+  ],
+  "command_caps": [
+    "ORDER_Attack"
+  ],
+  "guard_layer": "WL_AnySurface",
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        }
+      ]
+    }
+  },
+  "model": [
+    {
+      "layer": "WL_LandHorizontal",
+      "filename": "/pa/units/land/tactical_missile_launcher/tactical_missile_launcher.papa",
+      "animations": {
+        "start": "/pa/units/land/tactical_missile_launcher/tactical_missile_launcher_anim_start.papa",
+        "end": "/pa/units/land/tactical_missile_launcher/tactical_missile_launcher_anim_end.papa"
+      },
+      "animtree": "/pa/anim/anim_trees/tactical_missile_launcher_anim_tree.json",
+      "skirt_decal": "/pa/effects/specs/skirt_08.json"
+    },
+    {
+      "layer": "WL_WaterSurface",
+      "filename": "/pa/units/sea/tactical_missile_launcher/tactical_missile_launcher.papa",
+      "animations": {
+        "start": "/pa/units/land/tactical_missile_launcher/tactical_missile_launcher_anim_start.papa",
+        "end": "/pa/units/land/tactical_missile_launcher/tactical_missile_launcher_anim_end.papa"
+      },
+      "animtree": "/pa/anim/anim_trees/tactical_missile_launcher_anim_tree.json"
+    }
+  ],
+  "tools": [
+    {
+      "spec_id": "/pa/units/land/tactical_missile_launcher/tactical_missile_launcher_tool_weapon.json",
+      "aim_bone": "bone_missile01",
+      "muzzle_bone": "bone_missile01"
+    },
+    {
+      "spec_id": "/pa/units/land/tactical_missile_launcher/tactical_missile_tool_antidrop.json",
+      "aim_bone": "bone_missile01",
+      "muzzle_bone": "bone_missile01"
+    }
+  ],
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/factory"
+    },
+    "fired": {
+      "audio_cue": "/SE/Weapons/structure/tact_mis_launcher_catapult_fire",
+      "effect_spec": "/pa/units/land/tactical_missile_launcher/tactical_missile_launcher_launch.pfx"
+    },
+    "died": {
+      "audio_cue": "/SE/Death/Factory",
+      "effect_scale": 0.5
+    }
+  },
+  "audio": {
+    "selection_response": {
+      "cue": "/SE/Selection/structure/artillery"
+    }
+  },
+  "TEMP_texelinfo": 15.8261,
+  "mesh_bounds": [
+    9,
+    9,
+    8.7
+  ],
+  "fx_offsets": [
+    {
+      "type": "idle",
+      "filename": "/pa/units/land/tactical_missile_launcher/light_2_3_3.pfx",
+      "offset": [
+        3.9,
+        0.6,
+        8.8
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/tactical_missile_launcher/light_2_3_1.pfx",
+      "offset": [
+        -3.9,
+        -0.6,
+        8.8
+      ]
+    }
+  ]
 }

--- a/pa/units/land/teleporter/teleporter.json
+++ b/pa/units/land/teleporter/teleporter.json
@@ -1,189 +1,1064 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"unit_name": "!LOC(units:teleporter.message):Teleporter",
-	"display_name": "!LOC(units:teleporter.message):Teleporter",
-	"description": "!LOC(units:teleporter_teleports_units_from_one_to_another.message):Teleporter: Teleports units from one to another.",
-	"max_health": 9750,
-	"build_metal_cost": 800,
-	"atrophy_rate": 6.66667,
-	"atrophy_cool_down": 15.0,
-	"spawn_layers": "WL_LandHorizontal",
-	"area_build_type": "Line",
-	"energy_efficiency_requirement": 1.0,
-	"unit_types": ["UNITTYPE_Structure",
-	"UNITTYPE_Teleporter",
-	"UNITTYPE_CmdBuild",
-	"UNITTYPE_FabBuild",
-	"UNITTYPE_FabAdvBuild",
-	"UNITTYPE_CombatFabAdvBuild",
-	"UNITTYPE_CombatFabBuild",
-	"UNITTYPE_FabOrbBuild"],
-	"command_caps": ["ORDER_Move",
-	"ORDER_Patrol",
-	"ORDER_Reclaim",
-	"ORDER_Repair",
-	"ORDER_Attack",
-	"ORDER_Assist",
-	"ORDER_Use"],
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			}]
-		}
-	},
-	"model": {
-		"filename": "/pa/units/land/teleporter/teleporter.papa",
-		"animations": {
-			"start": "/pa/units/land/teleporter/teleporter_anim_start.papa",
-			"loop": "/pa/units/land/teleporter/teleporter_anim_loop.papa",
-			"end": "/pa/units/land/teleporter/teleporter_anim_end.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/powered_loop_anim_tree.json",
-		"skirt_decal": "/pa/effects/specs/skirt_teleporter.json"
-	},
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/energy"
-		},
-		"enabled": {
-			"audio_cue": "/SE/Buildings/teleporter_enabled",
-			"effect_spec": "/pa/units/land/teleporter/teleporter_power_on.pfx bone_innerRingMaster"
-		},
-		"disabled": {
-			"audio_cue": "/SE/Buildings/teleporter_disabled",
-			"effect_spec": "/pa/units/land/teleporter/teleporter_power_down.pfx bone_innerRingMaster"
-		},
-		"died": {
-			"audio_cue": "/SE/Death/Factory",
-			"effect_scale": 1.5
-		}
-	},
-	"audio": {
-		"loops": {
-			"enabled": {
-				"cue": "/SE/Buildings/teleporter_loop",
-				"flag": "enable_changed",
-				"should_start_func": "is_enabled",
-				"should_stop_func": "is_disabled"
-			}
-		}
-	},
-	"fx_offsets" : [{
-			"type" : "enabled",
-			"filename" : "/pa/units/land/teleporter/teleporter_event_horizon.pfx",
-			"bone" : "bone_innerRingMaster",
-			"offset" : [0, 0, 0],
-			"orientation" : [0, 0, 0]
-		}, {
-			"type" : "enabled",
-			"filename" : "/pa/units/land/teleporter/teleporter_brace_glow.pfx",
-			"bone" : "bone_innerRing01",
-			"offset" : [0, 0, 0],
-			"orientation" : [0, 0, 0]
-		}, {
-			"type" : "enabled",
-			"filename" : "/pa/units/land/teleporter/teleporter_brace_glow.pfx",
-			"bone" : "bone_innerRing02",
-			"offset" : [0, 0, 0],
-			"orientation" : [0, 0, 0]
-		}, {
-			"type" : "enabled",
-			"filename" : "/pa/units/land/teleporter/teleporter_brace_glow.pfx",
-			"bone" : "bone_innerRing03",
-			"offset" : [0, 0, 0],
-			"orientation" : [0, 0, 0]
-		}, {
-			"type" : "enabled",
-			"filename" : "/pa/units/land/teleporter/teleporter_brace_glow.pfx",
-			"bone" : "bone_innerRing04",
-			"offset" : [0, 0, 0],
-			"orientation" : [0, 0, 0]
-		},{
-			"label" : "Big Antenna Right",
-			"type" : "idle",
-			"filename" : "/pa/effects/specs/stable_light_2.pfx",
-			"bone" : "bone_root",
-			"offset" : [17.1, -11, 11.8]
-		},{
-			"label" : "Little Antenna Right",
-			"type" : "idle",
-			"filename" : "/pa/effects/specs/stable_light_2.pfx",
-			"bone" : "bone_root",
-			"offset" : [18.9, -11, 9.9]
-		},{
-			"label" : "Big Antenna Left",
-			"type" : "idle",
-			"filename" : "/pa/effects/specs/stable_light_2.pfx",
-			"bone" : "bone_root",
-			"offset" : [-17.1, -11, 11.8]
-		},{
-			"label" : "RAMPLEFT",
-			"type" : "idle",
-			"filename" : "/pa/units/land/teleporter/ramp_light_1.pfx",
-			"bone" : "bone_root",
-			"offset" : [-6.75, 4.8, 1.9]
-		},{
-			"label" : "RAMPMIDDLE",
-			"type" : "idle",
-			"filename" : "/pa/units/land/teleporter/ramp_light_1.pfx",
-			"bone" : "bone_root",
-			"offset" : [-0, 4.8, 1.9]
-		},{
-			"label" : "RAMPRIGHT",
-			"type" : "idle",
-			"filename" : "/pa/units/land/teleporter/ramp_light_1.pfx",
-			"bone" : "bone_root",
-			"offset" : [6.75, 4.8, 1.9]
-		},{
-			"label" : "RAMPBIGRIGHT",
-			"type" : "idle",
-			"filename" : "/pa/units/land/teleporter/ramp_light_big_1.pfx",
-			"bone" : "bone_root",
-			"offset" : [6.75, 15.2, 1.9]
-		},{
-			"label" : "RAMPBIGMIDDLE",
-			"type" : "idle",
-			"filename" : "/pa/units/land/teleporter/ramp_light_big_1.pfx",
-			"bone" : "bone_root",
-			"offset" : [0, 15.2, 1.9]
-		},{
-			"label" : "RAMPBIGLEFT",
-			"type" : "idle",
-			"filename" : "/pa/units/land/teleporter/ramp_light_big_1.pfx",
-			"bone" : "bone_root",
-			"offset" : [-6.75, 15.2, 1.9]
-		},{
-			"label" : "Little Antenna Left",
-			"type" : "idle",
-			"filename" : "/pa/effects/specs/stable_light_2.pfx",
-			"bone" : "bone_root",
-			"offset" : [-18.9, -11, 9.9]
-		}
-	],
-	"orders": {
-		"handler_type": "inert"
-	},
-	"teleporter": {
-		"energy_demand": 1000
-	},
-	"useable": {
-		"type": "teleporter",
-		"range": 30
-	},
-	"mesh_bounds": [42.4,
-	30,
-	34],
-	"placement_size": [50,
-	75],
-	"TEMP_texelinfo": 55.7884
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "unit_name": "!LOC(units:teleporter.message):Teleporter",
+  "display_name": "!LOC(units:teleporter.message):Teleporter",
+  "description": "!LOC(units:teleporter_teleports_units_from_one_to_another.message):Teleporter: Teleports units from one to another.",
+  "max_health": 9750,
+  "build_metal_cost": 800,
+  "atrophy_rate": 6.66667,
+  "atrophy_cool_down": 15.0,
+  "spawn_layers": "WL_LandHorizontal",
+  "area_build_type": "Line",
+  "energy_efficiency_requirement": 1.0,
+  "unit_types": [
+    "UNITTYPE_Structure",
+    "UNITTYPE_Teleporter",
+    "UNITTYPE_CmdBuild",
+    "UNITTYPE_FabBuild",
+    "UNITTYPE_FabAdvBuild",
+    "UNITTYPE_CombatFabAdvBuild",
+    "UNITTYPE_CombatFabBuild",
+    "UNITTYPE_FabOrbBuild"
+  ],
+  "command_caps": [
+    "ORDER_Move",
+    "ORDER_Patrol",
+    "ORDER_Reclaim",
+    "ORDER_Repair",
+    "ORDER_Attack",
+    "ORDER_Assist",
+    "ORDER_Use"
+  ],
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        }
+      ]
+    }
+  },
+  "model": {
+    "filename": "/pa/units/land/teleporter/teleporter.papa",
+    "animations": {
+      "start": "/pa/units/land/teleporter/teleporter_anim_start.papa",
+      "loop": "/pa/units/land/teleporter/teleporter_anim_loop.papa",
+      "end": "/pa/units/land/teleporter/teleporter_anim_end.papa"
+    },
+    "animtree": "/pa/anim/anim_trees/powered_loop_anim_tree.json",
+    "skirt_decal": "/pa/effects/specs/skirt_teleporter.json"
+  },
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/energy"
+    },
+    "enabled": {
+      "audio_cue": "/SE/Buildings/teleporter_enabled",
+      "effect_spec": "/pa/units/land/teleporter/teleporter_power_on.pfx bone_innerRingMaster"
+    },
+    "disabled": {
+      "audio_cue": "/SE/Buildings/teleporter_disabled",
+      "effect_spec": "/pa/units/land/teleporter/teleporter_power_down.pfx bone_innerRingMaster"
+    },
+    "died": {
+      "audio_cue": "/SE/Death/Factory",
+      "effect_scale": 1.5
+    }
+  },
+  "audio": {
+    "loops": {
+      "enabled": {
+        "cue": "/SE/Buildings/teleporter_loop",
+        "flag": "enable_changed",
+        "should_start_func": "is_enabled",
+        "should_stop_func": "is_disabled"
+      }
+    }
+  },
+  "fx_offsets": [
+    {
+      "type": "enabled",
+      "filename": "/pa/units/land/teleporter/teleporter_event_horizon.pfx",
+      "bone": "bone_innerRingMaster",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "enabled",
+      "filename": "/pa/units/land/teleporter/teleporter_brace_glow.pfx",
+      "bone": "bone_innerRing01",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "enabled",
+      "filename": "/pa/units/land/teleporter/teleporter_brace_glow.pfx",
+      "bone": "bone_innerRing02",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "enabled",
+      "filename": "/pa/units/land/teleporter/teleporter_brace_glow.pfx",
+      "bone": "bone_innerRing03",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "enabled",
+      "filename": "/pa/units/land/teleporter/teleporter_brace_glow.pfx",
+      "bone": "bone_innerRing04",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "label": "Big Antenna Right",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        17.1,
+        -11,
+        11.8
+      ]
+    },
+    {
+      "label": "Little Antenna Right",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        18.9,
+        -11,
+        9.9
+      ]
+    },
+    {
+      "label": "Big Antenna Left",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -17.1,
+        -11,
+        11.8
+      ]
+    },
+    {
+      "label": "RAMPLEFT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -6.75,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPMIDDLE",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        0,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPRIGHT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        6.75,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPBIGRIGHT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        6.75,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPBIGMIDDLE",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        0,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPBIGLEFT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -6.75,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "Little Antenna Left",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -18.9,
+        -11,
+        9.9
+      ]
+    },
+    {
+      "label": "Little Antenna Left",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -18.9,
+        -11,
+        9.9
+      ]
+    },
+    {
+      "label": "RAMPBIGLEFT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -6.75,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPBIGMIDDLE",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        0,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPBIGRIGHT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        6.75,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPRIGHT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        6.75,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPMIDDLE",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        0,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPLEFT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -6.75,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "Big Antenna Left",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -17.1,
+        -11,
+        11.8
+      ]
+    },
+    {
+      "label": "Little Antenna Right",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        18.9,
+        -11,
+        9.9
+      ]
+    },
+    {
+      "label": "Big Antenna Right",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        17.1,
+        -11,
+        11.8
+      ]
+    },
+    {
+      "label": "Big Antenna Right",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        17.1,
+        -11,
+        11.8
+      ]
+    },
+    {
+      "label": "Little Antenna Right",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        18.9,
+        -11,
+        9.9
+      ]
+    },
+    {
+      "label": "Big Antenna Left",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -17.1,
+        -11,
+        11.8
+      ]
+    },
+    {
+      "label": "RAMPLEFT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -6.75,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPMIDDLE",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        0,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPRIGHT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        6.75,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPBIGRIGHT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        6.75,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPBIGMIDDLE",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        0,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPBIGLEFT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -6.75,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "Little Antenna Left",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -18.9,
+        -11,
+        9.9
+      ]
+    },
+    {
+      "label": "Little Antenna Left",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -18.9,
+        -11,
+        9.9
+      ]
+    },
+    {
+      "label": "RAMPBIGLEFT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -6.75,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPBIGMIDDLE",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        0,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPBIGRIGHT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        6.75,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPRIGHT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        6.75,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPMIDDLE",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        0,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPLEFT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -6.75,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "Big Antenna Left",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -17.1,
+        -11,
+        11.8
+      ]
+    },
+    {
+      "label": "Little Antenna Right",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        18.9,
+        -11,
+        9.9
+      ]
+    },
+    {
+      "label": "Big Antenna Right",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        17.1,
+        -11,
+        11.8
+      ]
+    },
+    {
+      "label": "Big Antenna Right",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        17.1,
+        -11,
+        11.8
+      ]
+    },
+    {
+      "label": "Little Antenna Right",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        18.9,
+        -11,
+        9.9
+      ]
+    },
+    {
+      "label": "Big Antenna Left",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -17.1,
+        -11,
+        11.8
+      ]
+    },
+    {
+      "label": "RAMPLEFT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -6.75,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPMIDDLE",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        0,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPRIGHT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        6.75,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPBIGRIGHT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        6.75,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPBIGMIDDLE",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        0,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPBIGLEFT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -6.75,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "Little Antenna Left",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -18.9,
+        -11,
+        9.9
+      ]
+    },
+    {
+      "label": "Little Antenna Left",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -18.9,
+        -11,
+        9.9
+      ]
+    },
+    {
+      "label": "RAMPBIGLEFT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -6.75,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPBIGMIDDLE",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        0,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPBIGRIGHT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        6.75,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPRIGHT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        6.75,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPMIDDLE",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        0,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPLEFT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -6.75,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "Big Antenna Left",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -17.1,
+        -11,
+        11.8
+      ]
+    },
+    {
+      "label": "Little Antenna Right",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        18.9,
+        -11,
+        9.9
+      ]
+    },
+    {
+      "label": "Big Antenna Right",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        17.1,
+        -11,
+        11.8
+      ]
+    },
+    {
+      "label": "Big Antenna Right",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        17.1,
+        -11,
+        11.8
+      ]
+    },
+    {
+      "label": "Little Antenna Right",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        18.9,
+        -11,
+        9.9
+      ]
+    },
+    {
+      "label": "Big Antenna Left",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -17.1,
+        -11,
+        11.8
+      ]
+    },
+    {
+      "label": "RAMPLEFT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -6.75,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPMIDDLE",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        0,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPRIGHT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        6.75,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPBIGRIGHT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        6.75,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPBIGMIDDLE",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        0,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPBIGLEFT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -6.75,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "Little Antenna Left",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -18.9,
+        -11,
+        9.9
+      ]
+    },
+    {
+      "label": "Little Antenna Left",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -18.9,
+        -11,
+        9.9
+      ]
+    },
+    {
+      "label": "RAMPBIGLEFT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -6.75,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPBIGMIDDLE",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        0,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPBIGRIGHT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        6.75,
+        15.2,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPRIGHT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        6.75,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPMIDDLE",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        0,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "RAMPLEFT",
+      "type": "idle",
+      "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -6.75,
+        4.8,
+        1.9
+      ]
+    },
+    {
+      "label": "Big Antenna Left",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        -17.1,
+        -11,
+        11.8
+      ]
+    },
+    {
+      "label": "Little Antenna Right",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        18.9,
+        -11,
+        9.9
+      ]
+    },
+    {
+      "label": "Big Antenna Right",
+      "type": "idle",
+      "filename": "/pa/effects/specs/stable_light_2.pfx",
+      "bone": "bone_root",
+      "offset": [
+        17.1,
+        -11,
+        11.8
+      ]
+    }
+  ],
+  "orders": {
+    "handler_type": "inert"
+  },
+  "teleporter": {
+    "energy_demand": 1000
+  },
+  "useable": {
+    "type": "teleporter",
+    "range": 30
+  },
+  "mesh_bounds": [
+    42.4,
+    30,
+    34
+  ],
+  "placement_size": [
+    50,
+    75
+  ],
+  "TEMP_texelinfo": 55.7884
 }

--- a/pa/units/land/vehicle_factory/vehicle_factory.json
+++ b/pa/units/land/vehicle_factory/vehicle_factory.json
@@ -1,240 +1,1206 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:vehicle_factory.message):Vehicle Factory",
-	"description": "!LOC(units:basic_manufacturing_builds_land_vehicles.message):Basic manufacturing- Builds land vehicles.",
-	"max_health": 6000,
-	"build_metal_cost": 600,
-	"atrophy_rate": 10.0,
-	"atrophy_cool_down": 15.0,
-	"buildable_types": "(Land & Mobile & Tank & Basic | Tank & Fabber & Basic & Mobile) & FactoryBuild",
-	"rolloff_dirs": [[0,
-	1,
-	0],
-	[0,
-	-1,
-	0]],
-	"wait_to_rolloff_time": 0,
-	"factory_cooldown_time": 4,
-	"unit_types": ["UNITTYPE_Factory",
-	"UNITTYPE_Construction",
-	"UNITTYPE_Land",
-	"UNITTYPE_Tank",
-	"UNITTYPE_Structure",
-	"UNITTYPE_Basic",
-	"UNITTYPE_CmdBuild",
-	"UNITTYPE_FabBuild",
-	"UNITTYPE_FabAdvBuild",
-	"UNITTYPE_Important"],
-	"command_caps": ["ORDER_Move",
-	"ORDER_Patrol",
-	"ORDER_FactoryBuild",
-	"ORDER_Reclaim",
-	"ORDER_Repair",
-	"ORDER_Attack",
-	"ORDER_Assist",
-	"ORDER_Use"],
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			}]
-		}
-	},
-	"model": {
-		"filename": "/pa/units/land/vehicle_factory/vehicle_factory.papa",
-		"animations": {
-			"idle": "/pa/units/land/vehicle_factory/vehicle_factory_anim_build.papa",
-			"build_start": "/pa/units/land/vehicle_factory/vehicle_factory_anim_start.papa",
-			"build_loop": "/pa/units/land/vehicle_factory/vehicle_factory_anim_build.papa",
-			"build_end": "/pa/units/land/vehicle_factory/vehicle_factory_anim_end.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/factory_anim_tree.json",
-		"skirt_decal": "/pa/effects/specs/skirt_01.json"
-	},
-	"tools": [{
-		"spec_id": "/pa/units/land/vehicle_factory/vehicle_factory_build_arm.json",
-		"aim_bone": "bone_root"
-	}],
-	"events": {
-		"died": {
-			"effect_scale": 1.0
-		}
-	},
-	"audio": {
-		"loops": {
-			"build": {
-				"cue": "/SE/Construction/Factory_contruction_loop_veh",
-				"flag": "build_target_changed",
-				"should_start_func": "has_build_target",
-				"should_stop_func": "no_build_target"
-			}
-		}
-	},
-	"fx_offsets": [{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "bone_bar001",
-		"offset": [5.509,
-		2.718,
-		0],
-		"orientation": [0,
-		0,
-		135]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "bone_bar001",
-		"offset": [-5.51,
-		2.718,
-		0],
-		"orientation": [0,
-		0,
-		-135]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "bone_bar002",
-		"offset": [5.509,
-		2.718,
-		0],
-		"orientation": [0,
-		0,
-		135]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "bone_bar002",
-		"offset": [-5.51,
-		2.718,
-		0],
-		"orientation": [0,
-		0,
-		-135]
-	}, {
-			"type" : "build",
-			"bone": "bone_bar002",
-			"filename" : "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
-			"offset": [6.1, 2.1, 0.6]
-	}, {
-			"type" : "build",
-			"bone": "bone_bar002",
-			"filename" : "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
-			"offset": [0, 0.3, 0.6]
-	}, {
-			"type" : "build",
-			"bone": "bone_bar002",
-			"filename" : "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
-			"offset": [-6.1, 2.1, 0.6]
-	}, {
-			"type" : "build",
-			"bone": "bone_bar001",
-			"filename" : "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
-			"offset": [6.1, 2.1, 0.6]
-	}, {
-			"type" : "build",
-			"bone": "bone_bar001",
-			"filename" : "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
-			"offset": [0, 0.3, 0.6]
-	}, {
-			"type" : "build",
-			"bone": "bone_bar001",
-			"filename" : "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
-			"offset": [-6.1, 2.1, 0.6]
-	}, {
-			"type" : "idle",
-			"bone": "bone_bar002",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset": [6.1, 2.1, 0.6]
-	}, {
-			"type" : "idle",
-			"bone": "bone_bar002",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset": [0, 0.3, 0.6]
-	}, {
-			"type" : "idle",
-			"bone": "bone_bar002",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset": [-6.1, 2.1, 0.6]
-	}, {
-			"type" : "idle",
-			"bone": "bone_bar001",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset": [6.1, 2.1, 0.6]
-	}, {
-			"type" : "idle",
-			"bone": "bone_bar001",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset": [0, 0.3, 0.6]
-	}, {
-			"type" : "idle",
-			"bone": "bone_bar001",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset": [-6.1, 2.1, 0.6]
-	}],
-	"death": {
-		"decals": ["/pa/effects/specs/scorch_c_01.json"]
-	},
-	"headlights": [{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [0.0,
-		0.0,
-		20.0],
-		"orientation": [0.0,
-		0.0,
-		0.0],
-		"near_width": 20.0,
-		"near_height": 20.0,
-		"near_distance": 10.0,
-		"far_distance": 30.0,
-		"color": [1.5,
-		1.52,
-		1.6],
-		"debug": false
-	}],
-	"lamps": [{
-		"offset": [5.47,
-		-12.71,
-		11.0],
-		"radius": 6.0,
-		"color": [0.1,
-		1.0,
-		0.1],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-5.47,
-		-12.71,
-		11.0],
-		"radius": 6.0,
-		"color": [0.1,
-		1.0,
-		0.1],
-		"intensity": 2.0
-	},
-	{
-		"offset": [9.81,
-		10.88,
-		5.49],
-		"radius": 4.0,
-		"color": [1.0,
-		0.0,
-		0.0],
-		"intensity": 2.0
-	}],
-	"mesh_bounds": [30,
-	30,
-	15],
-	"placement_size": [30,
-	60],
-	"area_build_separation": 3,
-	"TEMP_texelinfo": 39.6154,
-	"physics": {
-		"collision_layers": "WL_AnyHorizontalGroundOrWaterSurface"
-	}
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:vehicle_factory.message):Vehicle Factory",
+  "description": "!LOC(units:basic_manufacturing_builds_land_vehicles.message):Basic manufacturing- Builds land vehicles.",
+  "max_health": 6000,
+  "build_metal_cost": 600,
+  "atrophy_rate": 10.0,
+  "atrophy_cool_down": 15.0,
+  "buildable_types": "(Land & Mobile & Tank & Basic | Tank & Fabber & Basic & Mobile) & FactoryBuild",
+  "rolloff_dirs": [
+    [
+      0,
+      1,
+      0
+    ],
+    [
+      0,
+      -1,
+      0
+    ]
+  ],
+  "wait_to_rolloff_time": 0,
+  "factory_cooldown_time": 4,
+  "unit_types": [
+    "UNITTYPE_Factory",
+    "UNITTYPE_Construction",
+    "UNITTYPE_Land",
+    "UNITTYPE_Tank",
+    "UNITTYPE_Structure",
+    "UNITTYPE_Basic",
+    "UNITTYPE_CmdBuild",
+    "UNITTYPE_FabBuild",
+    "UNITTYPE_FabAdvBuild",
+    "UNITTYPE_Important"
+  ],
+  "command_caps": [
+    "ORDER_Move",
+    "ORDER_Patrol",
+    "ORDER_FactoryBuild",
+    "ORDER_Reclaim",
+    "ORDER_Repair",
+    "ORDER_Attack",
+    "ORDER_Assist",
+    "ORDER_Use"
+  ],
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        }
+      ]
+    }
+  },
+  "model": {
+    "filename": "/pa/units/land/vehicle_factory/vehicle_factory.papa",
+    "animations": {
+      "idle": "/pa/units/land/vehicle_factory/vehicle_factory_anim_build.papa",
+      "build_start": "/pa/units/land/vehicle_factory/vehicle_factory_anim_start.papa",
+      "build_loop": "/pa/units/land/vehicle_factory/vehicle_factory_anim_build.papa",
+      "build_end": "/pa/units/land/vehicle_factory/vehicle_factory_anim_end.papa"
+    },
+    "animtree": "/pa/anim/anim_trees/factory_anim_tree.json",
+    "skirt_decal": "/pa/effects/specs/skirt_01.json"
+  },
+  "tools": [
+    {
+      "spec_id": "/pa/units/land/vehicle_factory/vehicle_factory_build_arm.json",
+      "aim_bone": "bone_root"
+    }
+  ],
+  "events": {
+    "died": {
+      "effect_scale": 1.0
+    }
+  },
+  "audio": {
+    "loops": {
+      "build": {
+        "cue": "/SE/Construction/Factory_contruction_loop_veh",
+        "flag": "build_target_changed",
+        "should_start_func": "has_build_target",
+        "should_stop_func": "no_build_target"
+      }
+    }
+  },
+  "fx_offsets": [
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "bone_bar001",
+      "offset": [
+        5.509,
+        2.718,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        135
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "bone_bar001",
+      "offset": [
+        -5.51,
+        2.718,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        -135
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "bone_bar002",
+      "offset": [
+        5.509,
+        2.718,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        135
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "bone_bar002",
+      "offset": [
+        -5.51,
+        2.718,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        -135
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar001",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_bar002",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar001",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        -6.1,
+        2.1,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
+      "offset": [
+        0,
+        0.3,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_bar002",
+      "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+      "offset": [
+        6.1,
+        2.1,
+        0.6
+      ]
+    }
+  ],
+  "death": {
+    "decals": [
+      "/pa/effects/specs/scorch_c_01.json"
+    ]
+  },
+  "headlights": [
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        0.0,
+        0.0,
+        20.0
+      ],
+      "orientation": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "near_width": 20.0,
+      "near_height": 20.0,
+      "near_distance": 10.0,
+      "far_distance": 30.0,
+      "color": [
+        1.5,
+        1.52,
+        1.6
+      ],
+      "debug": false
+    }
+  ],
+  "lamps": [
+    {
+      "offset": [
+        5.47,
+        -12.71,
+        11.0
+      ],
+      "radius": 6.0,
+      "color": [
+        0.1,
+        1.0,
+        0.1
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -5.47,
+        -12.71,
+        11.0
+      ],
+      "radius": 6.0,
+      "color": [
+        0.1,
+        1.0,
+        0.1
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        9.81,
+        10.88,
+        5.49
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "intensity": 2.0
+    }
+  ],
+  "mesh_bounds": [
+    30,
+    30,
+    15
+  ],
+  "placement_size": [
+    40,
+    60
+  ],
+  "area_build_separation": 2,
+  "TEMP_texelinfo": 39.6154,
+  "physics": {
+    "collision_layers": "WL_AnyHorizontalGroundOrWaterSurface"
+  }
 }

--- a/pa/units/land/vehicle_factory_adv/vehicle_factory_adv.json
+++ b/pa/units/land/vehicle_factory_adv/vehicle_factory_adv.json
@@ -1,374 +1,2260 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:advanced_vehicle_factory.message):Advanced Vehicle Factory",
-	"description": "!LOC(units:advanced_manufacturing_builds_land_vehicles.message):Advanced manufacturing- Builds land vehicles.",
-	"max_health": 30000,
-	"build_metal_cost": 4800,
-	"atrophy_rate": 80.0,
-	"atrophy_cool_down": 15.0,
-	"buildable_types": "Mobile & Tank & FactoryBuild",
-	"rolloff_dirs": [[0,
-	1,
-	0],
-	[0,
-	-1,
-	0]],
-	"wait_to_rolloff_time": 0,
-	"factory_cooldown_time": 4,
-	"unit_types": ["UNITTYPE_Factory",
-	"UNITTYPE_Construction",
-	"UNITTYPE_Land",
-	"UNITTYPE_Tank",
-	"UNITTYPE_Structure",
-	"UNITTYPE_Advanced",
-	"UNITTYPE_Important"],
-	"command_caps": ["ORDER_Move",
-	"ORDER_Patrol",
-	"ORDER_FactoryBuild",
-	"ORDER_Reclaim",
-	"ORDER_Repair",
-	"ORDER_Attack",
-	"ORDER_Assist",
-	"ORDER_Use"],
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			}]
-		}
-	},
-	"model": {
-		"filename": "/pa/units/land/vehicle_factory_adv/vehicle_factory_adv.papa",
-		"animations": {
-			"idle": "/pa/units/land/vehicle_factory_adv/vehicle_factory_adv_anim_build.papa",
-			"build_start": "/pa/units/land/vehicle_factory_adv/vehicle_factory_adv_anim_start.papa",
-			"build_loop": "/pa/units/land/vehicle_factory_adv/vehicle_factory_adv_anim_build.papa",
-			"build_end": "/pa/units/land/vehicle_factory_adv/vehicle_factory_adv_anim_end.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/factory_anim_tree.json",
-		"skirt_decal": "/pa/effects/specs/skirt_02.json"
-	},
-	"tools": [{
-		"spec_id": "/pa/units/land/vehicle_factory_adv/vehicle_factory_adv_build_arm.json",
-		"aim_bone": "bone_root"
-	}],
-	"events": {
-		"died": {
-			"effect_scale": 1.5
-		}
-	},
-	"audio": {
-		"loops": {
-			"build": {
-				"cue": "/SE/Construction/Factory_contruction_loop_veh",
-				"flag": "build_target_changed",
-				"should_start_func": "has_build_target",
-				"should_stop_func": "no_build_target"
-			}
-		}
-	},
-	"fx_offsets": [{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_nozzle01",
-		"offset": [0,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_nozzle02",
-		"offset": [0,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_nozzle03",
-		"offset": [0,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_nozzle04",
-		"offset": [0,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_nozzle05",
-		"offset": [0,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_nozzle06",
-		"offset": [0,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_nozzle07",
-		"offset": [0,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_nozzle08",
-		"offset": [0,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	}, {
-			"type" : "build",
-			"bone": "socket_nozzle01",
-			"filename" : "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
-			"offset": [4, 0.8, 0.6]
-	}, {
-			"type" : "build",
-			"bone": "socket_nozzle01",
-			"filename" : "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
-			"offset": [-4, 0.8, 0.6]
-	}, {
-			"type" : "build",
-			"bone": "socket_nozzle03",
-			"filename" : "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
-			"offset": [4, 0.8, 0.6]
-	}, {
-			"type" : "build",
-			"bone": "socket_nozzle03",
-			"filename" : "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
-			"offset": [-4, 0.8, 0.6]
-	}, {
-			"type" : "build",
-			"bone": "socket_nozzle05",
-			"filename" : "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
-			"offset": [4, 0.8, 0.6]
-	}, {
-			"type" : "build",
-			"bone": "socket_nozzle05",
-			"filename" : "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
-			"offset": [-4, 0.8, 0.6]
-	}, {
-			"type" : "build",
-			"bone": "socket_nozzle07",
-			"filename" : "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
-			"offset": [4, 0.8, 0.6]
-	}, {
-			"type" : "build",
-			"bone": "socket_nozzle07",
-			"filename" : "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
-			"offset": [-4, 0.8, 0.6]
-	}, {
-			"type" : "idle",
-			"bone": "socket_nozzle01",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset": [4, 0.8, 0.6]
-	}, {
-			"type" : "idle",
-			"bone": "socket_nozzle01",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset": [-4, 0.8, 0.6]
-	}, {
-			"type" : "idle",
-			"bone": "socket_nozzle03",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset": [4, 0.8, 0.6]
-	}, {
-			"type" : "idle",
-			"bone": "socket_nozzle03",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset": [-4, 0.8, 0.6]
-	}, {
-			"type" : "idle",
-			"bone": "socket_nozzle05",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset": [4, 0.8, 0.6]
-	}, {
-			"type" : "idle",
-			"bone": "socket_nozzle05",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset": [-4, 0.8, 0.6]
-	}, {
-			"type" : "idle",
-			"bone": "socket_nozzle07",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset": [4, 0.8, 0.6]
-	}, {
-			"type" : "idle",
-			"bone": "socket_nozzle07",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset": [-4, 0.8, 0.6]
-	}, {
-			"type" : "idle",
-			"bone": "bone_root",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset": [21, -3.5, 18.6]
-	}, {
-			"type" : "idle",
-			"bone": "Bone_root",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset": [21, 3.5, 18.6]
-	}, {
-			"type" : "idle",
-			"bone": "bone_root",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset": [-21, -3.5, 18.6]
-	}, {
-			"type" : "idle",
-			"bone": "Bone_root",
-			"filename" : "/pa/effects/specs/dot_1.pfx",
-			"offset": [-21, 3.5, 18.6]
-	}, {
-			"type" : "build",
-			"bone": "bone_root",
-			"filename" : "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
-			"offset": [21, -3.5, 18.6]
-	}, {
-			"type" : "build",
-			"bone": "Bone_root",
-			"filename" : "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
-			"offset": [21, 3.5, 18.6]
-	}, {
-			"type" : "build",
-			"bone": "bone_root",
-			"filename" : "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
-			"offset": [-21, -3.5, 18.6]
-	}, {
-			"type" : "build",
-			"bone": "Bone_root",
-			"filename" : "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
-			"offset": [-21, 3.5, 18.6]
-	}],
-	"headlights": [{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [0.0,
-		0.0,
-		30.0],
-		"orientation": [0.0,
-		0.0,
-		0.0],
-		"near_width": 30.0,
-		"near_height": 30.0,
-		"near_distance": 15.0,
-		"far_distance": 30.0,
-		"color": [1.5,
-		1.52,
-		1.6],
-		"debug": false
-	}],
-	"lamps": [{
-		"offset": [18.671,
-		-17.929,
-		15.64],
-		"radius": 8.0,
-		"color": [0.1,
-		1.0,
-		0.1],
-		"intensity": 2.0
-	},
-	{
-		"offset": [22.812,
-		-17.929,
-		11.32],
-		"radius": 8.0,
-		"color": [0.1,
-		1.0,
-		0.1],
-		"intensity": 2.0
-	},
-	{
-		"offset": [18.671,
-		17.929,
-		15.64],
-		"radius": 8.0,
-		"color": [0.1,
-		1.0,
-		0.1],
-		"intensity": 2.0
-	},
-	{
-		"offset": [22.812,
-		17.929,
-		11.32],
-		"radius": 8.0,
-		"color": [0.1,
-		1.0,
-		0.1],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-17.05,
-		25.28,
-		5.68],
-		"radius": 4.0,
-		"color": [1.0,
-		0.0,
-		0.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-17.05,
-		-25.28,
-		5.68],
-		"radius": 4.0,
-		"color": [1.0,
-		0.0,
-		0.0],
-		"intensity": 2.0
-	}],
-	"mesh_bounds": [50,
-	50,
-	23],
-	"placement_size": [50,
-	80],
-	"area_build_separation": 7,
-	"TEMP_texelinfo": 62.1789,
-	"physics": {
-		"collision_layers": "WL_AnyHorizontalGroundOrWaterSurface"
-	}
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:advanced_vehicle_factory.message):Advanced Vehicle Factory",
+  "description": "!LOC(units:advanced_manufacturing_builds_land_vehicles.message):Advanced manufacturing- Builds land vehicles.",
+  "max_health": 30000,
+  "build_metal_cost": 4800,
+  "atrophy_rate": 80.0,
+  "atrophy_cool_down": 15.0,
+  "buildable_types": "Mobile & Tank & FactoryBuild",
+  "rolloff_dirs": [
+    [
+      0,
+      1,
+      0
+    ],
+    [
+      0,
+      -1,
+      0
+    ]
+  ],
+  "wait_to_rolloff_time": 0,
+  "factory_cooldown_time": 4,
+  "unit_types": [
+    "UNITTYPE_Factory",
+    "UNITTYPE_Construction",
+    "UNITTYPE_Land",
+    "UNITTYPE_Tank",
+    "UNITTYPE_Structure",
+    "UNITTYPE_Advanced",
+    "UNITTYPE_Important"
+  ],
+  "command_caps": [
+    "ORDER_Move",
+    "ORDER_Patrol",
+    "ORDER_FactoryBuild",
+    "ORDER_Reclaim",
+    "ORDER_Repair",
+    "ORDER_Attack",
+    "ORDER_Assist",
+    "ORDER_Use"
+  ],
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        }
+      ]
+    }
+  },
+  "model": {
+    "filename": "/pa/units/land/vehicle_factory_adv/vehicle_factory_adv.papa",
+    "animations": {
+      "idle": "/pa/units/land/vehicle_factory_adv/vehicle_factory_adv_anim_build.papa",
+      "build_start": "/pa/units/land/vehicle_factory_adv/vehicle_factory_adv_anim_start.papa",
+      "build_loop": "/pa/units/land/vehicle_factory_adv/vehicle_factory_adv_anim_build.papa",
+      "build_end": "/pa/units/land/vehicle_factory_adv/vehicle_factory_adv_anim_end.papa"
+    },
+    "animtree": "/pa/anim/anim_trees/factory_anim_tree.json",
+    "skirt_decal": "/pa/effects/specs/skirt_02.json"
+  },
+  "tools": [
+    {
+      "spec_id": "/pa/units/land/vehicle_factory_adv/vehicle_factory_adv_build_arm.json",
+      "aim_bone": "bone_root"
+    }
+  ],
+  "events": {
+    "died": {
+      "effect_scale": 1.5
+    }
+  },
+  "audio": {
+    "loops": {
+      "build": {
+        "cue": "/SE/Construction/Factory_contruction_loop_veh",
+        "flag": "build_target_changed",
+        "should_start_func": "has_build_target",
+        "should_stop_func": "no_build_target"
+      }
+    }
+  },
+  "fx_offsets": [
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_nozzle01",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_nozzle02",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_nozzle03",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_nozzle04",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_nozzle05",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_nozzle06",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_nozzle07",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_nozzle08",
+      "offset": [
+        0,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "Bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "Bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
+      "offset": [
+        21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "Bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
+      "offset": [
+        21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
+      "offset": [
+        -21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "Bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
+      "offset": [
+        -21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "Bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
+      "offset": [
+        -21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
+      "offset": [
+        -21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "Bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
+      "offset": [
+        21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
+      "offset": [
+        21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "Bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "Bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "Bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "Bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
+      "offset": [
+        21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "Bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
+      "offset": [
+        21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
+      "offset": [
+        -21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "Bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
+      "offset": [
+        -21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "Bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
+      "offset": [
+        -21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
+      "offset": [
+        -21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "Bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
+      "offset": [
+        21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
+      "offset": [
+        21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "Bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "Bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "Bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "Bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
+      "offset": [
+        21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "Bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
+      "offset": [
+        21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
+      "offset": [
+        -21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "Bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
+      "offset": [
+        -21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "Bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
+      "offset": [
+        -21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
+      "offset": [
+        -21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "Bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
+      "offset": [
+        21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
+      "offset": [
+        21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "Bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "Bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "Bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "Bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
+      "offset": [
+        21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "Bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
+      "offset": [
+        21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
+      "offset": [
+        -21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "Bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
+      "offset": [
+        -21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "Bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
+      "offset": [
+        -21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
+      "offset": [
+        -21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "Bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
+      "offset": [
+        21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
+      "offset": [
+        21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "Bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "Bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        21,
+        3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        21,
+        -3.5,
+        18.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/effects/specs/dot_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle07",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle05",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle03",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        -4,
+        0.8,
+        0.6
+      ]
+    },
+    {
+      "type": "build",
+      "bone": "socket_nozzle01",
+      "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
+      "offset": [
+        4,
+        0.8,
+        0.6
+      ]
+    }
+  ],
+  "headlights": [
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        0.0,
+        0.0,
+        30.0
+      ],
+      "orientation": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "near_width": 30.0,
+      "near_height": 30.0,
+      "near_distance": 15.0,
+      "far_distance": 30.0,
+      "color": [
+        1.5,
+        1.52,
+        1.6
+      ],
+      "debug": false
+    }
+  ],
+  "lamps": [
+    {
+      "offset": [
+        18.671,
+        -17.929,
+        15.64
+      ],
+      "radius": 8.0,
+      "color": [
+        0.1,
+        1.0,
+        0.1
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        22.812,
+        -17.929,
+        11.32
+      ],
+      "radius": 8.0,
+      "color": [
+        0.1,
+        1.0,
+        0.1
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        18.671,
+        17.929,
+        15.64
+      ],
+      "radius": 8.0,
+      "color": [
+        0.1,
+        1.0,
+        0.1
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        22.812,
+        17.929,
+        11.32
+      ],
+      "radius": 8.0,
+      "color": [
+        0.1,
+        1.0,
+        0.1
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -17.05,
+        25.28,
+        5.68
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -17.05,
+        -25.28,
+        5.68
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "intensity": 2.0
+    }
+  ],
+  "mesh_bounds": [
+    50,
+    50,
+    23
+  ],
+  "placement_size": [
+    60,
+    80
+  ],
+  "area_build_separation": 2,
+  "TEMP_texelinfo": 62.1789,
+  "physics": {
+    "collision_layers": "WL_AnyHorizontalGroundOrWaterSurface"
+  }
 }

--- a/pa/units/orbital/deep_space_radar/deep_space_radar.json
+++ b/pa/units/orbital/deep_space_radar/deep_space_radar.json
@@ -1,184 +1,1099 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:orbital_and_deepspace_radar.message):Orbital and Deepspace Radar",
-	"description": "!LOC(units:orbital_and_deepspace_radar_orbital_and_celestial_radar_telemetry.message):Orbital and deepspace radar- Orbital and Celestial radar telemetry.",
-	"max_health": 750,
-	"build_metal_cost": 300,
-	"consumption": {
-		"energy": 150
-	},
-	"energy_efficiency_requirement": 0.9,
-	"atrophy_rate": 5,
-	"atrophy_cool_down": 15.0,
-	"spawn_layers": "WL_AnySurface",
-	"mesh_bounds": [29,
-	29,
-	15.2],
-	"unit_types": ["UNITTYPE_Orbital",
-	"UNITTYPE_Structure",
-	"UNITTYPE_Advanced",
-	"UNITTYPE_Recon",
-	"UNITTYPE_FabBuild",
-	"UNITTYPE_FabAdvBuild",
-	"UNITTYPE_Important"],
-	"physics": {
-		"collision_layers": "WL_AnySurface"
-	},
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 70
-			},
-			{
-				"layer": "celestial",
-				"channel": "sight",
-				"shape": "sphere",
-				"radius": 1,
-				"uses_energy": true
-			},
-			{
-				"layer": "orbital",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 500,
-				"uses_energy": true
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 70
-			}]
-		}
-	},
-	"model": [{
-		"layer": "WL_LandHorizontal",
-		"filename": "/pa/units/orbital/deep_space_radar/deep_space_radar.papa",
-		"animations": {
-			"start": "/pa/units/orbital/deep_space_radar/deep_space_radar_anim_start.papa",
-			"loop": "/pa/units/orbital/deep_space_radar/deep_space_radar_anim_loop.papa",
-			"end": "/pa/units/orbital/deep_space_radar/deep_space_radar_anim_end.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/powered_loop_anim_tree.json",
-		"skirt_decal": "/pa/effects/specs/skirt_orbital_radar.json"
-	},
-	{
-		"layer": "WL_WaterSurface",
-		"filename": "/pa/units/sea/deep_space_radar/deep_space_radar.papa",
-		"animations": {
-			"start": "/pa/units/orbital/deep_space_radar/deep_space_radar_anim_start.papa",
-			"loop": "/pa/units/orbital/deep_space_radar/deep_space_radar_anim_loop.papa",
-			"end": "/pa/units/orbital/deep_space_radar/deep_space_radar_anim_end.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/powered_loop_anim_tree.json"
-	}],
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/radar"
-		},
-		"died": {
-			"audio_cue": "/SE/Death/radar",
-			"effect_scale": 1.25
-		}
-	},
-	"fx_offsets": [{
-		"type": "energy",
-		"filename": "/pa/units/orbital/deep_space_radar/deep_space_radar_on.pfx",
-		"bone": "bone_antenna",
-		"offset": [14.0,
-		0.0,
-		0.0],
-		"orientation": [-90,
-		0,
-		0]
-	},
-	{
-		"type": "energy",
-		"filename": "/pa/units/orbital/deep_space_radar/deep_space_radar_door_on.pfx",
-		"bone": "bone_door01"
-	},
-	{
-		"type": "energy",
-		"filename": "/pa/units/orbital/deep_space_radar/deep_space_radar_door_on.pfx",
-		"bone": "bone_door02"
-	},
-	{
-		"type": "energy",
-		"filename": "/pa/units/orbital/deep_space_radar/deep_space_radar_door_on.pfx",
-		"bone": "bone_door03"
-	},
-	{
-		"type": "energy",
-		"filename": "/pa/units/orbital/deep_space_radar/deep_space_radar_door_on.pfx",
-		"bone": "bone_door04"
-	}, {
-			"type" : "idle",
-			"bone" : "bone_door01",
-			"filename" : "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
-			"offset" : [4.3, 0, 2.0]
-		},{
-			"type" : "idle",
-			"bone" : "bone_door01",
-			"filename" : "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
-			"offset" : [8.6, 0, 2.0]
-		}, {
-			"type" : "idle",
-			"bone" : "bone_door01",
-			"filename" : "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
-			"offset" : [10.9, 0, 1.3]
-		}, {
-			"type" : "idle",
-			"bone" : "bone_door02",
-			"filename" : "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
-			"offset" : [4.3, 0, 2.0]
-		},{
-			"type" : "idle",
-			"bone" : "bone_door02",
-			"filename" : "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
-			"offset" : [8.6, 0, 2.0]
-		},{
-			"type" : "idle",
-			"bone" : "bone_door02",
-			"filename" : "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
-			"offset" : [10.9, 0, 1.3]
-		}, {
-			"type" : "idle",
-			"bone" : "bone_door03",
-			"filename" : "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
-			"offset" : [4.3, 0, 2.0]
-		},{
-			"type" : "idle",
-			"bone" : "bone_door03",
-			"filename" : "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
-			"offset" : [8.6, 0, 2.0]
-		},{
-			"type" : "idle",
-			"bone" : "bone_door03",
-			"filename" : "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
-			"offset" : [10.9, 0, 1.3]
-		}, {
-			"type" : "idle",
-			"bone" : "bone_door04",
-			"filename" : "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
-			"offset" : [4.3, 0, 2.0]
-		},{
-			"type" : "idle",
-			"bone" : "bone_door04",
-			"filename" : "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
-			"offset" : [8.6, 0, 2.0]
-		}, {
-			"type" : "idle",
-			"bone" : "bone_door04",
-			"filename" : "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
-			"offset" : [10.9, 0, 1.3]
-		}],
-	"audio": {
-		"selection_response": {
-			"cue": "/SE/Selection/structure/radar"
-		}
-	},
-	"TEMP_texelinfo": 46.4947
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:orbital_and_deepspace_radar.message):Orbital and Deepspace Radar",
+  "description": "!LOC(units:orbital_and_deepspace_radar_orbital_and_celestial_radar_telemetry.message):Orbital and deepspace radar- Orbital and Celestial radar telemetry.",
+  "max_health": 750,
+  "build_metal_cost": 600,
+  "consumption": {
+    "energy": 150
+  },
+  "energy_efficiency_requirement": 0.9,
+  "atrophy_rate": 5,
+  "atrophy_cool_down": 15.0,
+  "spawn_layers": "WL_AnySurface",
+  "mesh_bounds": [
+    29,
+    29,
+    15.2
+  ],
+  "unit_types": [
+    "UNITTYPE_Orbital",
+    "UNITTYPE_Structure",
+    "UNITTYPE_Land",
+    "UNITTYPE_Advanced",
+    "UNITTYPE_Recon",
+    "UNITTYPE_FabBuild",
+    "UNITTYPE_FabAdvBuild",
+    "UNITTYPE_Important"
+  ],
+  "physics": {
+    "collision_layers": "WL_AnySurface"
+  },
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 70
+        },
+        {
+          "layer": "celestial",
+          "channel": "sight",
+          "shape": "sphere",
+          "radius": 1,
+          "uses_energy": true
+        },
+        {
+          "layer": "orbital",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 1000,
+          "uses_energy": true
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 70
+        }
+      ]
+    }
+  },
+  "model": [
+    {
+      "layer": "WL_LandHorizontal",
+      "filename": "/pa/units/orbital/deep_space_radar/deep_space_radar.papa",
+      "animations": {
+        "start": "/pa/units/orbital/deep_space_radar/deep_space_radar_anim_start.papa",
+        "loop": "/pa/units/orbital/deep_space_radar/deep_space_radar_anim_loop.papa",
+        "end": "/pa/units/orbital/deep_space_radar/deep_space_radar_anim_end.papa"
+      },
+      "animtree": "/pa/anim/anim_trees/powered_loop_anim_tree.json",
+      "skirt_decal": "/pa/effects/specs/skirt_orbital_radar.json"
+    },
+    {
+      "layer": "WL_WaterSurface",
+      "filename": "/pa/units/sea/deep_space_radar/deep_space_radar.papa",
+      "animations": {
+        "start": "/pa/units/orbital/deep_space_radar/deep_space_radar_anim_start.papa",
+        "loop": "/pa/units/orbital/deep_space_radar/deep_space_radar_anim_loop.papa",
+        "end": "/pa/units/orbital/deep_space_radar/deep_space_radar_anim_end.papa"
+      },
+      "animtree": "/pa/anim/anim_trees/powered_loop_anim_tree.json"
+    }
+  ],
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/radar"
+    },
+    "died": {
+      "audio_cue": "/SE/Death/radar",
+      "effect_scale": 1.25
+    }
+  },
+  "fx_offsets": [
+    {
+      "type": "energy",
+      "filename": "/pa/units/orbital/deep_space_radar/deep_space_radar_on.pfx",
+      "bone": "bone_antenna",
+      "offset": [
+        14.0,
+        0.0,
+        0.0
+      ],
+      "orientation": [
+        -90,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "energy",
+      "filename": "/pa/units/orbital/deep_space_radar/deep_space_radar_door_on.pfx",
+      "bone": "bone_door01"
+    },
+    {
+      "type": "energy",
+      "filename": "/pa/units/orbital/deep_space_radar/deep_space_radar_door_on.pfx",
+      "bone": "bone_door02"
+    },
+    {
+      "type": "energy",
+      "filename": "/pa/units/orbital/deep_space_radar/deep_space_radar_door_on.pfx",
+      "bone": "bone_door03"
+    },
+    {
+      "type": "energy",
+      "filename": "/pa/units/orbital/deep_space_radar/deep_space_radar_door_on.pfx",
+      "bone": "bone_door04"
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door04",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door03",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door02",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+      "offset": [
+        10.9,
+        0,
+        1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+      "offset": [
+        8.6,
+        0,
+        2.0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_door01",
+      "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+      "offset": [
+        4.3,
+        0,
+        2.0
+      ]
+    }
+  ],
+  "audio": {
+    "selection_response": {
+      "cue": "/SE/Selection/structure/radar"
+    }
+  },
+  "TEMP_texelinfo": 46.4947
 }

--- a/pa/units/orbital/delta_v_engine/delta_v_engine.json
+++ b/pa/units/orbital/delta_v_engine/delta_v_engine.json
@@ -1,372 +1,1775 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:halley.message):Halley",
-	"description": "!LOC(units:delta_v_engine_used_to_move_small_to_medium_celestial_bodies.message):Delta V Engine- Used to move small to medium celestial bodies.",
-	"max_health": 20000,
-	"build_metal_cost": 40000,
-	"atrophy_rate": 650,
-	"atrophy_cool_down": 15.0,
-	"spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
-	"build_restrictions": "Thrustable",
-	"unit_types": ["UNITTYPE_Orbital",
-	"UNITTYPE_Factory",
-	"UNITTYPE_Construction",
-	"UNITTYPE_Structure",
-	"UNITTYPE_Land",
-	"UNITTYPE_PlanetEngine",
-	"UNITTYPE_Advanced",
-	"UNITTYPE_FabAdvBuild",
-	"UNITTYPE_Important"],
-	"orbital_thruster": {
-		"power": 1
-	},
-	"recon": {
-		"observable": {
-			"always_visible": true
-		},
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 110
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 110
-			}]
-		}
-	},
-	"model": {
-		"filename": "/pa/units/orbital/delta_v_engine/delta_v_engine.papa",
-		"animations": {
-			"start": "/pa/units/orbital/delta_v_engine/delta_v_engine_anim_start.papa",
-			"loop": "/pa/units/orbital/delta_v_engine/delta_v_engine_anim_loop.papa",
-			"end": "/pa/units/orbital/delta_v_engine/delta_v_engine_anim_end.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/constant_idle_transition_anim_tree.json"
-	},
-	"audio": {
-		"loops": {
-			"enabled": {
-				"cue": "/SE/Celestial/Planet_Engines_Loop",
-				"flag": "enable_changed",
-				"should_start_func": "is_enabled",
-				"should_stop_func": "is_disabled",
-				"interplanetary": true
-			}
-		}
-	},
-	"fx_offsets" : [{
-			"type" : "enabled",
-			"filename" : "/pa/units/orbital/delta_v_engine/delta_v_jet.pfx",
-			"offset" : [0, 0, 21],
-			"orientation" : [0, 0, 0]
-		},{
-			"label" : "Big Antenna 1",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/effects/specs/light_2_4_2_2.pfx",
-			"offset" : [19.16, 19.9, 20.15]
-		},{
-			"label" : "Little Antenna 1",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/effects/specs/light_2_4_1_2.pfx",
-			"offset" : [19.9, 19.16, 18.60]
-		},{
-			"label" : "Big Antenna 2",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/effects/specs/light_2_4_2_2.pfx",
-			"offset" : [19.16, -19.9, 20.15]
-		},{
-			"label" : "Little Antenna 2",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/effects/specs/light_2_4_1_2.pfx",
-			"offset" : [19.9, -19.16, 18.60]
-		},{
-			"label" : "Big Antenna 3",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/effects/specs/light_2_4_2_2.pfx",
-			"offset" : [-19.9, -19.16, 20.15]
-		},{
-			"label" : "Little Antenna 3",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/effects/specs/light_2_4_1_2.pfx",
-			"offset" : [-19.16, -19.9, 18.60]
-		},{
-			"label" : "Big Antenna 4",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/effects/specs/light_2_4_2_2.pfx",
-			"offset" : [-19.9, 19.16, 20.15]
-		},{
-			"label" : "Little Antenna 4",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/effects/specs/light_2_4_1_2.pfx",
-			"offset" : [-19.16, 19.9, 18.60]
-		},{
-			"label" : "Upper Door 1",
-			"type" : "build",
-			"bone" : "bone_door01",
-			"filename" : "/pa/effects/specs/light_2_4_1_4.pfx",
-			"offset" : [9, 0, 2]
-		},{
-			"label" : "Upper Door 2",
-			"type" : "build",
-			"bone" : "bone_door02",
-			"filename" : "/pa/effects/specs/light_2_4_2_4.pfx",
-			"offset" : [9, 0, 2]
-		},{
-			"label" : "Upper Door 3",
-			"type" : "build",
-			"bone" : "bone_door03",
-			"filename" : "/pa/effects/specs/light_2_4_3_4.pfx",
-			"offset" : [9, 0, 2]
-		},{
-			"label" : "Upper Door 4",
-			"type" : "build",
-			"bone" : "bone_door04",
-			"filename" : "/pa/effects/specs/light_2_4_4_4.pfx",
-			"offset" : [9, 0, 2]
-		},{
-			"label" : "Upper Cross 1",
-			"type" : "idle",
-			"bone" : "bone_cross01",
-			"filename" : "/pa/effects/specs/light_1_4_4_2.pfx",
-			"offset" : [14.25, 0, 1.75]
-		},{
-			"label" : "Upper Cross 2",
-			"type" : "idle",
-			"bone" : "bone_cross02",
-			"filename" : "/pa/effects/specs/light_1_4_3_2.pfx",
-			"offset" : [14.25, 0, 1.75]
-		},{
-			"label" : "Upper Cross 3",
-			"type" : "idle",
-			"bone" : "bone_cross03",
-			"filename" : "/pa/effects/specs/light_1_4_2_2.pfx",
-			"offset" : [14.25, 0, 1.75]
-		},{
-			"label" : "Upper Cross 4",
-			"type" : "idle",
-			"bone" : "bone_cross04",
-			"filename" : "/pa/effects/specs/light_1_4_1_2.pfx", 
-			"offset" : [14.25, 0, 1.75]
-		}
-	],
-	"headlights": [{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [20.4,
-		20.4,
-		15.6],
-		"orientation": [25.0,
-		-23.0,
-		0.0],
-		"near_width": 5.5,
-		"near_height": 5.5,
-		"near_distance": 2.5,
-		"far_distance": 30.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 3.0
-	},
-	{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [20.4,
-		-20.4,
-		15.6],
-		"orientation": [25.0,
-		23.0,
-		0.0],
-		"near_width": 5.5,
-		"near_height": 5.5,
-		"near_distance": 2.5,
-		"far_distance": 30.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 3.0
-	},
-	{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [-20.4,
-		20.4,
-		15.6],
-		"orientation": [-25.0,
-		-23.0,
-		0.0],
-		"near_width": 5.5,
-		"near_height": 5.5,
-		"near_distance": 2.5,
-		"far_distance": 30.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 3.0
-	},
-	{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [-20.4,
-		-20.4,
-		15.6],
-		"orientation": [-25.0,
-		23.0,
-		0.0],
-		"near_width": 5.5,
-		"near_height": 5.5,
-		"near_distance": 2.5,
-		"far_distance": 30.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 3.0
-	}],
-	"lamps": [{
-		"offset": [-21.39,
-		9.9,
-		11.25],
-		"radius": 4.0,
-		"color": [1.0,
-		0.0,
-		0.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-21.39,
-		-9.9,
-		11.25],
-		"radius": 4.0,
-		"color": [1.0,
-		0.0,
-		0.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [25.44,
-		0.0,
-		12.4],
-		"radius": 4.0,
-		"color": [1.0,
-		0.0,
-		0.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-23.8,
-		0.0,
-		14.7],
-		"radius": 3.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [20.4,
-		20.4,
-		15.6],
-		"radius": 3.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [20.4,
-		-20.4,
-		15.6],
-		"radius": 3.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-20.4,
-		20.4,
-		15.6],
-		"radius": 3.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-20.4,
-		-20.4,
-		15.6],
-		"radius": 3.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [14.38,
-		0.0,
-		2.0],
-		"radius": 3.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0,
-		"bone": "bone_cross01"
-	},
-	{
-		"offset": [14.38,
-		0.0,
-		2.0],
-		"radius": 3.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0,
-		"bone": "bone_cross02"
-	},
-	{
-		"offset": [14.38,
-		0.0,
-		2.0],
-		"radius": 3.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0,
-		"bone": "bone_cross03"
-	},
-	{
-		"offset": [14.38,
-		0.0,
-		2.0],
-		"radius": 3.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0,
-		"bone": "bone_cross04"
-	}],
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/delta_v"
-		},
-		"died": {
-			"audio_cue": "/SE/Death/delta_v"
-		}
-	},
-	"TEMP_texelinfo": 77.8386,
-	"mesh_bounds": [50.0454,
-	50.0306,
-	43],
-	"physics": {
-		"collision_layers": "WL_AnyHorizontalGroundOrWaterSurface"
-	}
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:halley.message):Halley",
+  "description": "!LOC(units:delta_v_engine_used_to_move_small_to_medium_celestial_bodies.message):Delta V Engine- Used to move small to medium celestial bodies.",
+  "max_health": 20000,
+  "build_metal_cost": 40000,
+  "atrophy_rate": 650,
+  "atrophy_cool_down": 15.0,
+  "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
+  "build_restrictions": "Thrustable",
+  "unit_types": [
+    "UNITTYPE_Orbital",
+    "UNITTYPE_Factory",
+    "UNITTYPE_Construction",
+    "UNITTYPE_Structure",
+    "UNITTYPE_Land",
+    "UNITTYPE_PlanetEngine",
+    "UNITTYPE_Advanced",
+    "UNITTYPE_FabAdvBuild",
+    "UNITTYPE_Important"
+  ],
+  "orbital_thruster": {
+    "power": 1
+  },
+  "recon": {
+    "observable": {
+      "always_visible": true
+    },
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 110
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 110
+        }
+      ]
+    }
+  },
+  "model": {
+    "filename": "/pa/units/orbital/delta_v_engine/delta_v_engine.papa",
+    "animations": {
+      "start": "/pa/units/orbital/delta_v_engine/delta_v_engine_anim_start.papa",
+      "loop": "/pa/units/orbital/delta_v_engine/delta_v_engine_anim_loop.papa",
+      "end": "/pa/units/orbital/delta_v_engine/delta_v_engine_anim_end.papa"
+    },
+    "animtree": "/pa/anim/anim_trees/constant_idle_transition_anim_tree.json"
+  },
+  "audio": {
+    "loops": {
+      "enabled": {
+        "cue": "/SE/Celestial/Planet_Engines_Loop",
+        "flag": "enable_changed",
+        "should_start_func": "is_enabled",
+        "should_stop_func": "is_disabled",
+        "interplanetary": true
+      }
+    }
+  },
+  "fx_offsets": [
+    {
+      "type": "enabled",
+      "filename": "/pa/units/orbital/delta_v_engine/delta_v_jet.pfx",
+      "offset": [
+        0,
+        0,
+        21
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "label": "Big Antenna 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        19.16,
+        19.9,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        19.9,
+        19.16,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        19.16,
+        -19.9,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        19.9,
+        -19.16,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -19.9,
+        -19.16,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -19.16,
+        -19.9,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 4",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -19.9,
+        19.16,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 4",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -19.16,
+        19.9,
+        18.6
+      ]
+    },
+    {
+      "label": "Upper Door 1",
+      "type": "build",
+      "bone": "bone_door01",
+      "filename": "/pa/effects/specs/light_2_4_1_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 2",
+      "type": "build",
+      "bone": "bone_door02",
+      "filename": "/pa/effects/specs/light_2_4_2_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 3",
+      "type": "build",
+      "bone": "bone_door03",
+      "filename": "/pa/effects/specs/light_2_4_3_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 4",
+      "type": "build",
+      "bone": "bone_door04",
+      "filename": "/pa/effects/specs/light_2_4_4_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Cross 1",
+      "type": "idle",
+      "bone": "bone_cross01",
+      "filename": "/pa/effects/specs/light_1_4_4_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 2",
+      "type": "idle",
+      "bone": "bone_cross02",
+      "filename": "/pa/effects/specs/light_1_4_3_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 3",
+      "type": "idle",
+      "bone": "bone_cross03",
+      "filename": "/pa/effects/specs/light_1_4_2_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 4",
+      "type": "idle",
+      "bone": "bone_cross04",
+      "filename": "/pa/effects/specs/light_1_4_1_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 4",
+      "type": "idle",
+      "bone": "bone_cross04",
+      "filename": "/pa/effects/specs/light_1_4_1_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 3",
+      "type": "idle",
+      "bone": "bone_cross03",
+      "filename": "/pa/effects/specs/light_1_4_2_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 2",
+      "type": "idle",
+      "bone": "bone_cross02",
+      "filename": "/pa/effects/specs/light_1_4_3_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 1",
+      "type": "idle",
+      "bone": "bone_cross01",
+      "filename": "/pa/effects/specs/light_1_4_4_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Door 4",
+      "type": "build",
+      "bone": "bone_door04",
+      "filename": "/pa/effects/specs/light_2_4_4_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 3",
+      "type": "build",
+      "bone": "bone_door03",
+      "filename": "/pa/effects/specs/light_2_4_3_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 2",
+      "type": "build",
+      "bone": "bone_door02",
+      "filename": "/pa/effects/specs/light_2_4_2_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 1",
+      "type": "build",
+      "bone": "bone_door01",
+      "filename": "/pa/effects/specs/light_2_4_1_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Little Antenna 4",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -19.16,
+        19.9,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 4",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -19.9,
+        19.16,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -19.16,
+        -19.9,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -19.9,
+        -19.16,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        19.9,
+        -19.16,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        19.16,
+        -19.9,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        19.9,
+        19.16,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        19.16,
+        19.9,
+        20.15
+      ]
+    },
+    {
+      "label": "Big Antenna 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        19.16,
+        19.9,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        19.9,
+        19.16,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        19.16,
+        -19.9,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        19.9,
+        -19.16,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -19.9,
+        -19.16,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -19.16,
+        -19.9,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 4",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -19.9,
+        19.16,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 4",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -19.16,
+        19.9,
+        18.6
+      ]
+    },
+    {
+      "label": "Upper Door 1",
+      "type": "build",
+      "bone": "bone_door01",
+      "filename": "/pa/effects/specs/light_2_4_1_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 2",
+      "type": "build",
+      "bone": "bone_door02",
+      "filename": "/pa/effects/specs/light_2_4_2_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 3",
+      "type": "build",
+      "bone": "bone_door03",
+      "filename": "/pa/effects/specs/light_2_4_3_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 4",
+      "type": "build",
+      "bone": "bone_door04",
+      "filename": "/pa/effects/specs/light_2_4_4_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Cross 1",
+      "type": "idle",
+      "bone": "bone_cross01",
+      "filename": "/pa/effects/specs/light_1_4_4_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 2",
+      "type": "idle",
+      "bone": "bone_cross02",
+      "filename": "/pa/effects/specs/light_1_4_3_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 3",
+      "type": "idle",
+      "bone": "bone_cross03",
+      "filename": "/pa/effects/specs/light_1_4_2_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 4",
+      "type": "idle",
+      "bone": "bone_cross04",
+      "filename": "/pa/effects/specs/light_1_4_1_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 4",
+      "type": "idle",
+      "bone": "bone_cross04",
+      "filename": "/pa/effects/specs/light_1_4_1_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 3",
+      "type": "idle",
+      "bone": "bone_cross03",
+      "filename": "/pa/effects/specs/light_1_4_2_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 2",
+      "type": "idle",
+      "bone": "bone_cross02",
+      "filename": "/pa/effects/specs/light_1_4_3_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 1",
+      "type": "idle",
+      "bone": "bone_cross01",
+      "filename": "/pa/effects/specs/light_1_4_4_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Door 4",
+      "type": "build",
+      "bone": "bone_door04",
+      "filename": "/pa/effects/specs/light_2_4_4_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 3",
+      "type": "build",
+      "bone": "bone_door03",
+      "filename": "/pa/effects/specs/light_2_4_3_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 2",
+      "type": "build",
+      "bone": "bone_door02",
+      "filename": "/pa/effects/specs/light_2_4_2_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 1",
+      "type": "build",
+      "bone": "bone_door01",
+      "filename": "/pa/effects/specs/light_2_4_1_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Little Antenna 4",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -19.16,
+        19.9,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 4",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -19.9,
+        19.16,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -19.16,
+        -19.9,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -19.9,
+        -19.16,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        19.9,
+        -19.16,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        19.16,
+        -19.9,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        19.9,
+        19.16,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        19.16,
+        19.9,
+        20.15
+      ]
+    },
+    {
+      "label": "Big Antenna 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        19.16,
+        19.9,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        19.9,
+        19.16,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        19.16,
+        -19.9,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        19.9,
+        -19.16,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -19.9,
+        -19.16,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -19.16,
+        -19.9,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 4",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -19.9,
+        19.16,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 4",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -19.16,
+        19.9,
+        18.6
+      ]
+    },
+    {
+      "label": "Upper Door 1",
+      "type": "build",
+      "bone": "bone_door01",
+      "filename": "/pa/effects/specs/light_2_4_1_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 2",
+      "type": "build",
+      "bone": "bone_door02",
+      "filename": "/pa/effects/specs/light_2_4_2_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 3",
+      "type": "build",
+      "bone": "bone_door03",
+      "filename": "/pa/effects/specs/light_2_4_3_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 4",
+      "type": "build",
+      "bone": "bone_door04",
+      "filename": "/pa/effects/specs/light_2_4_4_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Cross 1",
+      "type": "idle",
+      "bone": "bone_cross01",
+      "filename": "/pa/effects/specs/light_1_4_4_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 2",
+      "type": "idle",
+      "bone": "bone_cross02",
+      "filename": "/pa/effects/specs/light_1_4_3_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 3",
+      "type": "idle",
+      "bone": "bone_cross03",
+      "filename": "/pa/effects/specs/light_1_4_2_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 4",
+      "type": "idle",
+      "bone": "bone_cross04",
+      "filename": "/pa/effects/specs/light_1_4_1_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 4",
+      "type": "idle",
+      "bone": "bone_cross04",
+      "filename": "/pa/effects/specs/light_1_4_1_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 3",
+      "type": "idle",
+      "bone": "bone_cross03",
+      "filename": "/pa/effects/specs/light_1_4_2_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 2",
+      "type": "idle",
+      "bone": "bone_cross02",
+      "filename": "/pa/effects/specs/light_1_4_3_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 1",
+      "type": "idle",
+      "bone": "bone_cross01",
+      "filename": "/pa/effects/specs/light_1_4_4_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Door 4",
+      "type": "build",
+      "bone": "bone_door04",
+      "filename": "/pa/effects/specs/light_2_4_4_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 3",
+      "type": "build",
+      "bone": "bone_door03",
+      "filename": "/pa/effects/specs/light_2_4_3_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 2",
+      "type": "build",
+      "bone": "bone_door02",
+      "filename": "/pa/effects/specs/light_2_4_2_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 1",
+      "type": "build",
+      "bone": "bone_door01",
+      "filename": "/pa/effects/specs/light_2_4_1_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Little Antenna 4",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -19.16,
+        19.9,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 4",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -19.9,
+        19.16,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -19.16,
+        -19.9,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -19.9,
+        -19.16,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        19.9,
+        -19.16,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        19.16,
+        -19.9,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        19.9,
+        19.16,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        19.16,
+        19.9,
+        20.15
+      ]
+    },
+    {
+      "label": "Big Antenna 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        19.16,
+        19.9,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        19.9,
+        19.16,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        19.16,
+        -19.9,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        19.9,
+        -19.16,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -19.9,
+        -19.16,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -19.16,
+        -19.9,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 4",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -19.9,
+        19.16,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 4",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -19.16,
+        19.9,
+        18.6
+      ]
+    },
+    {
+      "label": "Upper Door 1",
+      "type": "build",
+      "bone": "bone_door01",
+      "filename": "/pa/effects/specs/light_2_4_1_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 2",
+      "type": "build",
+      "bone": "bone_door02",
+      "filename": "/pa/effects/specs/light_2_4_2_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 3",
+      "type": "build",
+      "bone": "bone_door03",
+      "filename": "/pa/effects/specs/light_2_4_3_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 4",
+      "type": "build",
+      "bone": "bone_door04",
+      "filename": "/pa/effects/specs/light_2_4_4_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Cross 1",
+      "type": "idle",
+      "bone": "bone_cross01",
+      "filename": "/pa/effects/specs/light_1_4_4_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 2",
+      "type": "idle",
+      "bone": "bone_cross02",
+      "filename": "/pa/effects/specs/light_1_4_3_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 3",
+      "type": "idle",
+      "bone": "bone_cross03",
+      "filename": "/pa/effects/specs/light_1_4_2_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 4",
+      "type": "idle",
+      "bone": "bone_cross04",
+      "filename": "/pa/effects/specs/light_1_4_1_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 4",
+      "type": "idle",
+      "bone": "bone_cross04",
+      "filename": "/pa/effects/specs/light_1_4_1_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 3",
+      "type": "idle",
+      "bone": "bone_cross03",
+      "filename": "/pa/effects/specs/light_1_4_2_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 2",
+      "type": "idle",
+      "bone": "bone_cross02",
+      "filename": "/pa/effects/specs/light_1_4_3_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Cross 1",
+      "type": "idle",
+      "bone": "bone_cross01",
+      "filename": "/pa/effects/specs/light_1_4_4_2.pfx",
+      "offset": [
+        14.25,
+        0,
+        1.75
+      ]
+    },
+    {
+      "label": "Upper Door 4",
+      "type": "build",
+      "bone": "bone_door04",
+      "filename": "/pa/effects/specs/light_2_4_4_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 3",
+      "type": "build",
+      "bone": "bone_door03",
+      "filename": "/pa/effects/specs/light_2_4_3_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 2",
+      "type": "build",
+      "bone": "bone_door02",
+      "filename": "/pa/effects/specs/light_2_4_2_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Upper Door 1",
+      "type": "build",
+      "bone": "bone_door01",
+      "filename": "/pa/effects/specs/light_2_4_1_4.pfx",
+      "offset": [
+        9,
+        0,
+        2
+      ]
+    },
+    {
+      "label": "Little Antenna 4",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -19.16,
+        19.9,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 4",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -19.9,
+        19.16,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -19.16,
+        -19.9,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -19.9,
+        -19.16,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        19.9,
+        -19.16,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        19.16,
+        -19.9,
+        20.15
+      ]
+    },
+    {
+      "label": "Little Antenna 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        19.9,
+        19.16,
+        18.6
+      ]
+    },
+    {
+      "label": "Big Antenna 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        19.16,
+        19.9,
+        20.15
+      ]
+    }
+  ],
+  "headlights": [
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        20.4,
+        20.4,
+        15.6
+      ],
+      "orientation": [
+        25.0,
+        -23.0,
+        0.0
+      ],
+      "near_width": 5.5,
+      "near_height": 5.5,
+      "near_distance": 2.5,
+      "far_distance": 30.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 3.0
+    },
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        20.4,
+        -20.4,
+        15.6
+      ],
+      "orientation": [
+        25.0,
+        23.0,
+        0.0
+      ],
+      "near_width": 5.5,
+      "near_height": 5.5,
+      "near_distance": 2.5,
+      "far_distance": 30.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 3.0
+    },
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        -20.4,
+        20.4,
+        15.6
+      ],
+      "orientation": [
+        -25.0,
+        -23.0,
+        0.0
+      ],
+      "near_width": 5.5,
+      "near_height": 5.5,
+      "near_distance": 2.5,
+      "far_distance": 30.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 3.0
+    },
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        -20.4,
+        -20.4,
+        15.6
+      ],
+      "orientation": [
+        -25.0,
+        23.0,
+        0.0
+      ],
+      "near_width": 5.5,
+      "near_height": 5.5,
+      "near_distance": 2.5,
+      "far_distance": 30.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 3.0
+    }
+  ],
+  "lamps": [
+    {
+      "offset": [
+        -21.39,
+        9.9,
+        11.25
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -21.39,
+        -9.9,
+        11.25
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        25.44,
+        0.0,
+        12.4
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -23.8,
+        0.0,
+        14.7
+      ],
+      "radius": 3.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        20.4,
+        20.4,
+        15.6
+      ],
+      "radius": 3.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        20.4,
+        -20.4,
+        15.6
+      ],
+      "radius": 3.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -20.4,
+        20.4,
+        15.6
+      ],
+      "radius": 3.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -20.4,
+        -20.4,
+        15.6
+      ],
+      "radius": 3.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        14.38,
+        0.0,
+        2.0
+      ],
+      "radius": 3.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0,
+      "bone": "bone_cross01"
+    },
+    {
+      "offset": [
+        14.38,
+        0.0,
+        2.0
+      ],
+      "radius": 3.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0,
+      "bone": "bone_cross02"
+    },
+    {
+      "offset": [
+        14.38,
+        0.0,
+        2.0
+      ],
+      "radius": 3.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0,
+      "bone": "bone_cross03"
+    },
+    {
+      "offset": [
+        14.38,
+        0.0,
+        2.0
+      ],
+      "radius": 3.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0,
+      "bone": "bone_cross04"
+    }
+  ],
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/delta_v"
+    },
+    "died": {
+      "audio_cue": "/SE/Death/delta_v"
+    }
+  },
+  "TEMP_texelinfo": 77.8386,
+  "mesh_bounds": [
+    50.0454,
+    50.0306,
+    43
+  ],
+  "physics": {
+    "collision_layers": "WL_AnyHorizontalGroundOrWaterSurface"
+  }
 }

--- a/pa/units/orbital/mining_platform/mining_platform.json
+++ b/pa/units/orbital/mining_platform/mining_platform.json
@@ -1,277 +1,1885 @@
 {
-	"base_spec": "/pa/units/orbital/base_orbital_structure/base_orbital_structure.json",
-	"display_name": "!LOC(units:jig.message):Jig",
-	"description": "!LOC(units:gas_mining_and_metal_creation_satellite_only_works_above_gas_giant_planets.message):Gas mining and metal creation satellite. Only works above gas giant planets.",
-	"max_health": 500,
-	"build_metal_cost": 3000,
-	"spawn_layers": "WL_Orbital",
-	"area_build_type": "Sphere",
-	"area_build_separation": 50,
-	"build_restrictions": "Terrainless",
-	"production": {
-		"energy": 9000,
-		"metal": 36
-	},
-	"storage": {
-		"energy": 50000,
-		"metal": 10000
-	},
-	"unit_types": ["UNITTYPE_Orbital",
-	"UNITTYPE_FabOrbBuild",
-	"UNITTYPE_EnergyProduction",
-	"UNITTYPE_MetalProduction",
-	"UNITTYPE_Structure",
-	"UNITTYPE_Economy"],
-	"physics": {
-		"radius": 20,
-		"push_class": 15,
-		"collision_layers": "WL_Orbital",
-		"ignore_gravity": true
-	},
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "orbital",
-				"channel": "sight",
-				"shape": "sphere",
-				"radius": 250
-			}]
-		}
-	},
-	"model": {
-		"filename": "/pa/units/orbital/mining_platform/mining_platform.papa",
-		"animations": {
-			"start": "/pa/units/orbital/mining_platform/mining_platform_anim_start.papa",
-			"loop": "/pa/units/orbital/mining_platform/mining_platform_anim_loop.papa",
-			"end": "/pa/units/orbital/mining_platform/mining_platform_anim_loop.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/constant_idle_transition_anim_tree.json"
-	},
-	"audio": {
-		"loops": {
-			"enabled": {
-				"cue": "/SE/Celestial/Planet_Engines_Loop",
-				"flag": "enable_changed",
-				"should_start_func": "is_enabled",
-				"should_stop_func": "is_disabled"
-			}
-		}
-	},
-	"death_weapon": {
-		"ground_ammo_spec": "/pa/ammo/nuke_pbaoe/nuke_orbitalpbaoe.json"
-	},
-	"fx_offsets" : [{
-			"type" : "idle",
-			"filename" : "/pa/units/orbital/mining_platform/mining_platform_idle.pfx",
-			"offset" : [0, 0, 15.875]
-		}, {
-			"type" : "idle",
-			"filename" : "/pa/units/orbital/mining_platform/mining_platform_idle_tip.pfx",
-			"offset" : [0, 0, 52.5],
-			"bone" : "bone_hose07"
-		},{
-			"label" : "Energy Plant Light 1",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/orbital/mining_platform/energy_light_2_4_2_2.pfx",
-			"offset" : [0, -7.9, 26.8]
-		},{
-			"label" : "Energy Plant Light 2",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/orbital/mining_platform/energy_light_2_4_3_2.pfx",
-			"offset" : [-7.9, 0, 26.8]
-		},{
-			"label" : "Energy Plant Light 3",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/orbital/mining_platform/energy_light_2_4_1_2.pfx",
-			"offset" : [7.9, 0, 26.8]
-		},{
-			"label" : "Border Light S1-E1",
-			"type" : "idle",
-			"bone" : "bone_shield01",
-			"filename" : "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
-			"offset" : [-21.95, 5.1, 5.9]
-		},{
-			"label" : "Border Light S1-E4",
-			"type" : "idle",
-			"bone" : "bone_shield01",
-			"filename" : "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
-			"offset" : [21.95, 5.1, 5.9]
-		},{
-			"label" : "Border Light S2-E2",
-			"type" : "idle",
-			"bone" : "bone_shield02",
-			"filename" : "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
-			"offset" : [-21.95, 5.1, 5.9]
-		},{
-			"label" : "Border Light S2-E1",
-			"type" : "idle",
-			"bone" : "bone_shield02",
-			"filename" : "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
-			"offset" : [21.95, 5.1, 5.9]
-		},{
-			"label" : "Border Light S3-E3",
-			"type" : "idle",
-			"bone" : "bone_shield03",
-			"filename" : "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
-			"offset" : [-21.95, 5.1, 5.9]
-		},{
-			"label" : "Border Light S3-E2",
-			"type" : "idle",
-			"bone" : "bone_shield03",
-			"filename" : "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
-			"offset" : [21.95, 5.1, 5.9]
-		},{
-			"label" : "Border Light S4-E4",
-			"type" : "idle",
-			"bone" : "bone_shield04",
-			"filename" : "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
-			"offset" : [-21.95, 5.1, 5.9]
-		},{
-			"label" : "Border Light S4-E3",
-			"type" : "idle",
-			"bone" : "bone_shield04",
-			"filename" : "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
-			"offset" : [21.95, 5.1, 5.9]
-		},{
-			"label" : "Bottom Antenna",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/orbital/mining_platform/straw_2_8_8.pfx",
-			"offset" : [0.5, 0.5, -53.3]
-		},{
-			"label" : "Straw 7",
-			"type" : "idle",
-			"bone" : "bone_hose01",
-			"filename" : "/pa/units/orbital/mining_platform/straw_2_8_7.pfx",
-			"offset" : [0, -5.2, -3]
-		},{
-			"label" : "Straw 6",
-			"type" : "idle",
-			"bone" : "bone_hose02",
-			"filename" : "/pa/units/orbital/mining_platform/straw_2_8_6.pfx",
-			"offset" : [0, -11, -2]
-		},{
-			"label" : "Straw 5",
-			"type" : "idle",
-			"bone" : "bone_hose03",
-			"filename" : "/pa/units/orbital/mining_platform/straw_2_8_5.pfx",
-			"offset" : [0, -4, 0]
-		},{
-			"label" : "Straw 4",
-			"type" : "idle",
-			"bone" : "bone_hose04",
-			"filename" : "/pa/units/orbital/mining_platform/straw_2_8_4.pfx",
-			"offset" : [0, 0, 0]
-		},{
-			"label" : "Straw 3",
-			"type" : "idle",
-			"bone" : "bone_hose05",
-			"filename" : "/pa/units/orbital/mining_platform/straw_2_8_3.pfx",
-			"offset" : [0, -3, 0]
-		},{
-			"label" : "Straw 2",
-			"type" : "idle",
-			"bone" : "bone_hose06",
-			"filename" : "/pa/units/orbital/mining_platform/straw_2_8_2.pfx",
-			"offset" : [0, -8, 0]
-		},{
-			"label" : "Straw 1",
-			"type" : "idle",
-			"bone" : "bone_hose07",
-			"filename" : "/pa/units/orbital/mining_platform/straw_2_8_1.pfx",
-			"offset" : [0, -2, 0]
-		}
-	],
-	"lamps": [{
-		"offset": [0.0,
-		-4.15,
-		0.0],
-		"radius": 4.5,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0,
-		"bone": "bone_rotator02"
-	},
-	{
-		"offset": [-3.59,
-		2.08,
-		0.0],
-		"radius": 4.5,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0,
-		"bone": "bone_rotator02"
-	},
-	{
-		"offset": [3.59,
-		2.08,
-		0.0],
-		"radius": 4.5,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0,
-		"bone": "bone_rotator02"
-	},
-	{
-		"offset": [0.0,
-		7.43,
-		24.87],
-		"radius": 4.0,
-		"color": [1.0,
-		0.0,
-		0.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [0.0,
-		17.87,
-		22.0],
-		"radius": 4.0,
-		"color": [1.0,
-		0.0,
-		0.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [20.5,
-		0.0,
-		0.6],
-		"radius": 6.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0
-	},
-	{
-		"offset": [-20.5,
-		0.0,
-		0.6],
-		"radius": 6.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 1.0
-	}],
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/orbital_platform"
-		},
-		"died": {
-			"audio_cue": "/SE/Death/orbital",
-			"effect_spec": "/pa/effects/specs/mining_platform_orbital_explosion.pfx",
-			"effect_scale": 1.0
-		}
-	},
-	"mesh_bounds": [50,
-	50,
-	50],
-	"placement_size": [100,
-	100],
-	"TEMP_texelinfo": 72.293
+  "base_spec": "/pa/units/orbital/base_orbital_structure/base_orbital_structure.json",
+  "display_name": "!LOC(units:jig.message):Jig",
+  "description": "!LOC(units:gas_mining_and_metal_creation_satellite_only_works_above_gas_giant_planets.message):Gas mining and metal creation satellite. Only works above gas giant planets.",
+  "max_health": 500,
+  "build_metal_cost": 3000,
+  "atrophy_rate": 50.0,
+  "atrophy_cool_down": 15.0,
+  "spawn_layers": "WL_Orbital",
+  "area_build_type": "Sphere",
+  "area_build_separation": 100,
+  "build_restrictions": "Terrainless",
+  "production": {
+    "energy": 9000,
+    "metal": 36
+  },
+  "storage": {
+    "energy": 50000,
+    "metal": 10000
+  },
+  "unit_types": [
+    "UNITTYPE_Orbital",
+    "UNITTYPE_FabOrbBuild",
+    "UNITTYPE_EnergyProduction",
+    "UNITTYPE_MetalProduction",
+    "UNITTYPE_Structure",
+    "UNITTYPE_Economy"
+  ],
+  "physics": {
+    "radius": 20,
+    "push_class": 15,
+    "collision_layers": "WL_Orbital",
+    "ignore_gravity": true
+  },
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "orbital",
+          "channel": "sight",
+          "shape": "sphere",
+          "radius": 250
+        }
+      ]
+    }
+  },
+  "model": {
+    "filename": "/pa/units/orbital/mining_platform/mining_platform.papa",
+    "animations": {
+      "start": "/pa/units/orbital/mining_platform/mining_platform_anim_start.papa",
+      "loop": "/pa/units/orbital/mining_platform/mining_platform_anim_loop.papa",
+      "end": "/pa/units/orbital/mining_platform/mining_platform_anim_loop.papa"
+    },
+    "animtree": "/pa/anim/anim_trees/constant_idle_transition_anim_tree.json"
+  },
+  "audio": {
+    "loops": {
+      "enabled": {
+        "cue": "/SE/Celestial/Planet_Engines_Loop",
+        "flag": "enable_changed",
+        "should_start_func": "is_enabled",
+        "should_stop_func": "is_disabled"
+      }
+    }
+  },
+  "death_weapon": {
+    "ground_ammo_spec": "/pa/ammo/nuke_pbaoe/nuke_orbitalpbaoe.json"
+  },
+  "fx_offsets": [
+    {
+      "type": "idle",
+      "filename": "/pa/units/orbital/mining_platform/mining_platform_idle.pfx",
+      "offset": [
+        0,
+        0,
+        15.875
+      ]
+    },
+    {
+      "type": "idle",
+      "filename": "/pa/units/orbital/mining_platform/mining_platform_idle_tip.pfx",
+      "offset": [
+        0,
+        0,
+        52.5
+      ],
+      "bone": "bone_hose07"
+    },
+    {
+      "label": "Energy Plant Light 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_2_2.pfx",
+      "offset": [
+        0,
+        -7.9,
+        26.8
+      ]
+    },
+    {
+      "label": "Energy Plant Light 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_3_2.pfx",
+      "offset": [
+        -7.9,
+        0,
+        26.8
+      ]
+    },
+    {
+      "label": "Energy Plant Light 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_1_2.pfx",
+      "offset": [
+        7.9,
+        0,
+        26.8
+      ]
+    },
+    {
+      "label": "Border Light S1-E1",
+      "type": "idle",
+      "bone": "bone_shield01",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S1-E4",
+      "type": "idle",
+      "bone": "bone_shield01",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S2-E2",
+      "type": "idle",
+      "bone": "bone_shield02",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S2-E1",
+      "type": "idle",
+      "bone": "bone_shield02",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S3-E3",
+      "type": "idle",
+      "bone": "bone_shield03",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S3-E2",
+      "type": "idle",
+      "bone": "bone_shield03",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S4-E4",
+      "type": "idle",
+      "bone": "bone_shield04",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S4-E3",
+      "type": "idle",
+      "bone": "bone_shield04",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Bottom Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_8.pfx",
+      "offset": [
+        0.5,
+        0.5,
+        -53.3
+      ]
+    },
+    {
+      "label": "Straw 7",
+      "type": "idle",
+      "bone": "bone_hose01",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_7.pfx",
+      "offset": [
+        0,
+        -5.2,
+        -3
+      ]
+    },
+    {
+      "label": "Straw 6",
+      "type": "idle",
+      "bone": "bone_hose02",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_6.pfx",
+      "offset": [
+        0,
+        -11,
+        -2
+      ]
+    },
+    {
+      "label": "Straw 5",
+      "type": "idle",
+      "bone": "bone_hose03",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_5.pfx",
+      "offset": [
+        0,
+        -4,
+        0
+      ]
+    },
+    {
+      "label": "Straw 4",
+      "type": "idle",
+      "bone": "bone_hose04",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_4.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "label": "Straw 3",
+      "type": "idle",
+      "bone": "bone_hose05",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_3.pfx",
+      "offset": [
+        0,
+        -3,
+        0
+      ]
+    },
+    {
+      "label": "Straw 2",
+      "type": "idle",
+      "bone": "bone_hose06",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_2.pfx",
+      "offset": [
+        0,
+        -8,
+        0
+      ]
+    },
+    {
+      "label": "Straw 1",
+      "type": "idle",
+      "bone": "bone_hose07",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_1.pfx",
+      "offset": [
+        0,
+        -2,
+        0
+      ]
+    },
+    {
+      "label": "Straw 1",
+      "type": "idle",
+      "bone": "bone_hose07",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_1.pfx",
+      "offset": [
+        0,
+        -2,
+        0
+      ]
+    },
+    {
+      "label": "Straw 2",
+      "type": "idle",
+      "bone": "bone_hose06",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_2.pfx",
+      "offset": [
+        0,
+        -8,
+        0
+      ]
+    },
+    {
+      "label": "Straw 3",
+      "type": "idle",
+      "bone": "bone_hose05",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_3.pfx",
+      "offset": [
+        0,
+        -3,
+        0
+      ]
+    },
+    {
+      "label": "Straw 4",
+      "type": "idle",
+      "bone": "bone_hose04",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_4.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "label": "Straw 5",
+      "type": "idle",
+      "bone": "bone_hose03",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_5.pfx",
+      "offset": [
+        0,
+        -4,
+        0
+      ]
+    },
+    {
+      "label": "Straw 6",
+      "type": "idle",
+      "bone": "bone_hose02",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_6.pfx",
+      "offset": [
+        0,
+        -11,
+        -2
+      ]
+    },
+    {
+      "label": "Straw 7",
+      "type": "idle",
+      "bone": "bone_hose01",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_7.pfx",
+      "offset": [
+        0,
+        -5.2,
+        -3
+      ]
+    },
+    {
+      "label": "Bottom Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_8.pfx",
+      "offset": [
+        0.5,
+        0.5,
+        -53.3
+      ]
+    },
+    {
+      "label": "Border Light S4-E3",
+      "type": "idle",
+      "bone": "bone_shield04",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S4-E4",
+      "type": "idle",
+      "bone": "bone_shield04",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S3-E2",
+      "type": "idle",
+      "bone": "bone_shield03",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S3-E3",
+      "type": "idle",
+      "bone": "bone_shield03",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S2-E1",
+      "type": "idle",
+      "bone": "bone_shield02",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S2-E2",
+      "type": "idle",
+      "bone": "bone_shield02",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S1-E4",
+      "type": "idle",
+      "bone": "bone_shield01",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S1-E1",
+      "type": "idle",
+      "bone": "bone_shield01",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Energy Plant Light 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_1_2.pfx",
+      "offset": [
+        7.9,
+        0,
+        26.8
+      ]
+    },
+    {
+      "label": "Energy Plant Light 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_3_2.pfx",
+      "offset": [
+        -7.9,
+        0,
+        26.8
+      ]
+    },
+    {
+      "label": "Energy Plant Light 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_2_2.pfx",
+      "offset": [
+        0,
+        -7.9,
+        26.8
+      ]
+    },
+    {
+      "label": "Energy Plant Light 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_2_2.pfx",
+      "offset": [
+        0,
+        -7.9,
+        26.8
+      ]
+    },
+    {
+      "label": "Energy Plant Light 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_3_2.pfx",
+      "offset": [
+        -7.9,
+        0,
+        26.8
+      ]
+    },
+    {
+      "label": "Energy Plant Light 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_1_2.pfx",
+      "offset": [
+        7.9,
+        0,
+        26.8
+      ]
+    },
+    {
+      "label": "Border Light S1-E1",
+      "type": "idle",
+      "bone": "bone_shield01",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S1-E4",
+      "type": "idle",
+      "bone": "bone_shield01",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S2-E2",
+      "type": "idle",
+      "bone": "bone_shield02",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S2-E1",
+      "type": "idle",
+      "bone": "bone_shield02",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S3-E3",
+      "type": "idle",
+      "bone": "bone_shield03",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S3-E2",
+      "type": "idle",
+      "bone": "bone_shield03",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S4-E4",
+      "type": "idle",
+      "bone": "bone_shield04",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S4-E3",
+      "type": "idle",
+      "bone": "bone_shield04",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Bottom Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_8.pfx",
+      "offset": [
+        0.5,
+        0.5,
+        -53.3
+      ]
+    },
+    {
+      "label": "Straw 7",
+      "type": "idle",
+      "bone": "bone_hose01",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_7.pfx",
+      "offset": [
+        0,
+        -5.2,
+        -3
+      ]
+    },
+    {
+      "label": "Straw 6",
+      "type": "idle",
+      "bone": "bone_hose02",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_6.pfx",
+      "offset": [
+        0,
+        -11,
+        -2
+      ]
+    },
+    {
+      "label": "Straw 5",
+      "type": "idle",
+      "bone": "bone_hose03",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_5.pfx",
+      "offset": [
+        0,
+        -4,
+        0
+      ]
+    },
+    {
+      "label": "Straw 4",
+      "type": "idle",
+      "bone": "bone_hose04",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_4.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "label": "Straw 3",
+      "type": "idle",
+      "bone": "bone_hose05",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_3.pfx",
+      "offset": [
+        0,
+        -3,
+        0
+      ]
+    },
+    {
+      "label": "Straw 2",
+      "type": "idle",
+      "bone": "bone_hose06",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_2.pfx",
+      "offset": [
+        0,
+        -8,
+        0
+      ]
+    },
+    {
+      "label": "Straw 1",
+      "type": "idle",
+      "bone": "bone_hose07",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_1.pfx",
+      "offset": [
+        0,
+        -2,
+        0
+      ]
+    },
+    {
+      "label": "Straw 1",
+      "type": "idle",
+      "bone": "bone_hose07",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_1.pfx",
+      "offset": [
+        0,
+        -2,
+        0
+      ]
+    },
+    {
+      "label": "Straw 2",
+      "type": "idle",
+      "bone": "bone_hose06",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_2.pfx",
+      "offset": [
+        0,
+        -8,
+        0
+      ]
+    },
+    {
+      "label": "Straw 3",
+      "type": "idle",
+      "bone": "bone_hose05",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_3.pfx",
+      "offset": [
+        0,
+        -3,
+        0
+      ]
+    },
+    {
+      "label": "Straw 4",
+      "type": "idle",
+      "bone": "bone_hose04",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_4.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "label": "Straw 5",
+      "type": "idle",
+      "bone": "bone_hose03",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_5.pfx",
+      "offset": [
+        0,
+        -4,
+        0
+      ]
+    },
+    {
+      "label": "Straw 6",
+      "type": "idle",
+      "bone": "bone_hose02",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_6.pfx",
+      "offset": [
+        0,
+        -11,
+        -2
+      ]
+    },
+    {
+      "label": "Straw 7",
+      "type": "idle",
+      "bone": "bone_hose01",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_7.pfx",
+      "offset": [
+        0,
+        -5.2,
+        -3
+      ]
+    },
+    {
+      "label": "Bottom Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_8.pfx",
+      "offset": [
+        0.5,
+        0.5,
+        -53.3
+      ]
+    },
+    {
+      "label": "Border Light S4-E3",
+      "type": "idle",
+      "bone": "bone_shield04",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S4-E4",
+      "type": "idle",
+      "bone": "bone_shield04",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S3-E2",
+      "type": "idle",
+      "bone": "bone_shield03",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S3-E3",
+      "type": "idle",
+      "bone": "bone_shield03",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S2-E1",
+      "type": "idle",
+      "bone": "bone_shield02",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S2-E2",
+      "type": "idle",
+      "bone": "bone_shield02",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S1-E4",
+      "type": "idle",
+      "bone": "bone_shield01",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S1-E1",
+      "type": "idle",
+      "bone": "bone_shield01",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Energy Plant Light 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_1_2.pfx",
+      "offset": [
+        7.9,
+        0,
+        26.8
+      ]
+    },
+    {
+      "label": "Energy Plant Light 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_3_2.pfx",
+      "offset": [
+        -7.9,
+        0,
+        26.8
+      ]
+    },
+    {
+      "label": "Energy Plant Light 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_2_2.pfx",
+      "offset": [
+        0,
+        -7.9,
+        26.8
+      ]
+    },
+    {
+      "label": "Energy Plant Light 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_2_2.pfx",
+      "offset": [
+        0,
+        -7.9,
+        26.8
+      ]
+    },
+    {
+      "label": "Energy Plant Light 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_3_2.pfx",
+      "offset": [
+        -7.9,
+        0,
+        26.8
+      ]
+    },
+    {
+      "label": "Energy Plant Light 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_1_2.pfx",
+      "offset": [
+        7.9,
+        0,
+        26.8
+      ]
+    },
+    {
+      "label": "Border Light S1-E1",
+      "type": "idle",
+      "bone": "bone_shield01",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S1-E4",
+      "type": "idle",
+      "bone": "bone_shield01",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S2-E2",
+      "type": "idle",
+      "bone": "bone_shield02",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S2-E1",
+      "type": "idle",
+      "bone": "bone_shield02",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S3-E3",
+      "type": "idle",
+      "bone": "bone_shield03",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S3-E2",
+      "type": "idle",
+      "bone": "bone_shield03",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S4-E4",
+      "type": "idle",
+      "bone": "bone_shield04",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S4-E3",
+      "type": "idle",
+      "bone": "bone_shield04",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Bottom Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_8.pfx",
+      "offset": [
+        0.5,
+        0.5,
+        -53.3
+      ]
+    },
+    {
+      "label": "Straw 7",
+      "type": "idle",
+      "bone": "bone_hose01",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_7.pfx",
+      "offset": [
+        0,
+        -5.2,
+        -3
+      ]
+    },
+    {
+      "label": "Straw 6",
+      "type": "idle",
+      "bone": "bone_hose02",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_6.pfx",
+      "offset": [
+        0,
+        -11,
+        -2
+      ]
+    },
+    {
+      "label": "Straw 5",
+      "type": "idle",
+      "bone": "bone_hose03",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_5.pfx",
+      "offset": [
+        0,
+        -4,
+        0
+      ]
+    },
+    {
+      "label": "Straw 4",
+      "type": "idle",
+      "bone": "bone_hose04",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_4.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "label": "Straw 3",
+      "type": "idle",
+      "bone": "bone_hose05",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_3.pfx",
+      "offset": [
+        0,
+        -3,
+        0
+      ]
+    },
+    {
+      "label": "Straw 2",
+      "type": "idle",
+      "bone": "bone_hose06",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_2.pfx",
+      "offset": [
+        0,
+        -8,
+        0
+      ]
+    },
+    {
+      "label": "Straw 1",
+      "type": "idle",
+      "bone": "bone_hose07",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_1.pfx",
+      "offset": [
+        0,
+        -2,
+        0
+      ]
+    },
+    {
+      "label": "Straw 1",
+      "type": "idle",
+      "bone": "bone_hose07",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_1.pfx",
+      "offset": [
+        0,
+        -2,
+        0
+      ]
+    },
+    {
+      "label": "Straw 2",
+      "type": "idle",
+      "bone": "bone_hose06",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_2.pfx",
+      "offset": [
+        0,
+        -8,
+        0
+      ]
+    },
+    {
+      "label": "Straw 3",
+      "type": "idle",
+      "bone": "bone_hose05",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_3.pfx",
+      "offset": [
+        0,
+        -3,
+        0
+      ]
+    },
+    {
+      "label": "Straw 4",
+      "type": "idle",
+      "bone": "bone_hose04",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_4.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "label": "Straw 5",
+      "type": "idle",
+      "bone": "bone_hose03",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_5.pfx",
+      "offset": [
+        0,
+        -4,
+        0
+      ]
+    },
+    {
+      "label": "Straw 6",
+      "type": "idle",
+      "bone": "bone_hose02",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_6.pfx",
+      "offset": [
+        0,
+        -11,
+        -2
+      ]
+    },
+    {
+      "label": "Straw 7",
+      "type": "idle",
+      "bone": "bone_hose01",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_7.pfx",
+      "offset": [
+        0,
+        -5.2,
+        -3
+      ]
+    },
+    {
+      "label": "Bottom Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_8.pfx",
+      "offset": [
+        0.5,
+        0.5,
+        -53.3
+      ]
+    },
+    {
+      "label": "Border Light S4-E3",
+      "type": "idle",
+      "bone": "bone_shield04",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S4-E4",
+      "type": "idle",
+      "bone": "bone_shield04",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S3-E2",
+      "type": "idle",
+      "bone": "bone_shield03",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S3-E3",
+      "type": "idle",
+      "bone": "bone_shield03",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S2-E1",
+      "type": "idle",
+      "bone": "bone_shield02",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S2-E2",
+      "type": "idle",
+      "bone": "bone_shield02",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S1-E4",
+      "type": "idle",
+      "bone": "bone_shield01",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S1-E1",
+      "type": "idle",
+      "bone": "bone_shield01",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Energy Plant Light 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_1_2.pfx",
+      "offset": [
+        7.9,
+        0,
+        26.8
+      ]
+    },
+    {
+      "label": "Energy Plant Light 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_3_2.pfx",
+      "offset": [
+        -7.9,
+        0,
+        26.8
+      ]
+    },
+    {
+      "label": "Energy Plant Light 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_2_2.pfx",
+      "offset": [
+        0,
+        -7.9,
+        26.8
+      ]
+    },
+    {
+      "label": "Energy Plant Light 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_2_2.pfx",
+      "offset": [
+        0,
+        -7.9,
+        26.8
+      ]
+    },
+    {
+      "label": "Energy Plant Light 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_3_2.pfx",
+      "offset": [
+        -7.9,
+        0,
+        26.8
+      ]
+    },
+    {
+      "label": "Energy Plant Light 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_1_2.pfx",
+      "offset": [
+        7.9,
+        0,
+        26.8
+      ]
+    },
+    {
+      "label": "Border Light S1-E1",
+      "type": "idle",
+      "bone": "bone_shield01",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S1-E4",
+      "type": "idle",
+      "bone": "bone_shield01",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S2-E2",
+      "type": "idle",
+      "bone": "bone_shield02",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S2-E1",
+      "type": "idle",
+      "bone": "bone_shield02",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S3-E3",
+      "type": "idle",
+      "bone": "bone_shield03",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S3-E2",
+      "type": "idle",
+      "bone": "bone_shield03",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S4-E4",
+      "type": "idle",
+      "bone": "bone_shield04",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S4-E3",
+      "type": "idle",
+      "bone": "bone_shield04",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Bottom Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_8.pfx",
+      "offset": [
+        0.5,
+        0.5,
+        -53.3
+      ]
+    },
+    {
+      "label": "Straw 7",
+      "type": "idle",
+      "bone": "bone_hose01",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_7.pfx",
+      "offset": [
+        0,
+        -5.2,
+        -3
+      ]
+    },
+    {
+      "label": "Straw 6",
+      "type": "idle",
+      "bone": "bone_hose02",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_6.pfx",
+      "offset": [
+        0,
+        -11,
+        -2
+      ]
+    },
+    {
+      "label": "Straw 5",
+      "type": "idle",
+      "bone": "bone_hose03",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_5.pfx",
+      "offset": [
+        0,
+        -4,
+        0
+      ]
+    },
+    {
+      "label": "Straw 4",
+      "type": "idle",
+      "bone": "bone_hose04",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_4.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "label": "Straw 3",
+      "type": "idle",
+      "bone": "bone_hose05",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_3.pfx",
+      "offset": [
+        0,
+        -3,
+        0
+      ]
+    },
+    {
+      "label": "Straw 2",
+      "type": "idle",
+      "bone": "bone_hose06",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_2.pfx",
+      "offset": [
+        0,
+        -8,
+        0
+      ]
+    },
+    {
+      "label": "Straw 1",
+      "type": "idle",
+      "bone": "bone_hose07",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_1.pfx",
+      "offset": [
+        0,
+        -2,
+        0
+      ]
+    },
+    {
+      "label": "Straw 1",
+      "type": "idle",
+      "bone": "bone_hose07",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_1.pfx",
+      "offset": [
+        0,
+        -2,
+        0
+      ]
+    },
+    {
+      "label": "Straw 2",
+      "type": "idle",
+      "bone": "bone_hose06",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_2.pfx",
+      "offset": [
+        0,
+        -8,
+        0
+      ]
+    },
+    {
+      "label": "Straw 3",
+      "type": "idle",
+      "bone": "bone_hose05",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_3.pfx",
+      "offset": [
+        0,
+        -3,
+        0
+      ]
+    },
+    {
+      "label": "Straw 4",
+      "type": "idle",
+      "bone": "bone_hose04",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_4.pfx",
+      "offset": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "label": "Straw 5",
+      "type": "idle",
+      "bone": "bone_hose03",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_5.pfx",
+      "offset": [
+        0,
+        -4,
+        0
+      ]
+    },
+    {
+      "label": "Straw 6",
+      "type": "idle",
+      "bone": "bone_hose02",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_6.pfx",
+      "offset": [
+        0,
+        -11,
+        -2
+      ]
+    },
+    {
+      "label": "Straw 7",
+      "type": "idle",
+      "bone": "bone_hose01",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_7.pfx",
+      "offset": [
+        0,
+        -5.2,
+        -3
+      ]
+    },
+    {
+      "label": "Bottom Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/straw_2_8_8.pfx",
+      "offset": [
+        0.5,
+        0.5,
+        -53.3
+      ]
+    },
+    {
+      "label": "Border Light S4-E3",
+      "type": "idle",
+      "bone": "bone_shield04",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S4-E4",
+      "type": "idle",
+      "bone": "bone_shield04",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S3-E2",
+      "type": "idle",
+      "bone": "bone_shield03",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S3-E3",
+      "type": "idle",
+      "bone": "bone_shield03",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S2-E1",
+      "type": "idle",
+      "bone": "bone_shield02",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S2-E2",
+      "type": "idle",
+      "bone": "bone_shield02",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S1-E4",
+      "type": "idle",
+      "bone": "bone_shield01",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
+      "offset": [
+        21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Border Light S1-E1",
+      "type": "idle",
+      "bone": "bone_shield01",
+      "filename": "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
+      "offset": [
+        -21.95,
+        5.1,
+        5.9
+      ]
+    },
+    {
+      "label": "Energy Plant Light 3",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_1_2.pfx",
+      "offset": [
+        7.9,
+        0,
+        26.8
+      ]
+    },
+    {
+      "label": "Energy Plant Light 2",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_3_2.pfx",
+      "offset": [
+        -7.9,
+        0,
+        26.8
+      ]
+    },
+    {
+      "label": "Energy Plant Light 1",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_2_2.pfx",
+      "offset": [
+        0,
+        -7.9,
+        26.8
+      ]
+    }
+  ],
+  "lamps": [
+    {
+      "offset": [
+        0.0,
+        -4.15,
+        0.0
+      ],
+      "radius": 4.5,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0,
+      "bone": "bone_rotator02"
+    },
+    {
+      "offset": [
+        -3.59,
+        2.08,
+        0.0
+      ],
+      "radius": 4.5,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0,
+      "bone": "bone_rotator02"
+    },
+    {
+      "offset": [
+        3.59,
+        2.08,
+        0.0
+      ],
+      "radius": 4.5,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0,
+      "bone": "bone_rotator02"
+    },
+    {
+      "offset": [
+        0.0,
+        7.43,
+        24.87
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        0.0,
+        17.87,
+        22.0
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        20.5,
+        0.0,
+        0.6
+      ],
+      "radius": 6.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0
+    },
+    {
+      "offset": [
+        -20.5,
+        0.0,
+        0.6
+      ],
+      "radius": 6.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 1.0
+    }
+  ],
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/orbital_platform"
+    },
+    "died": {
+      "audio_cue": "/SE/Death/orbital",
+      "effect_spec": "/pa/effects/specs/mining_platform_orbital_explosion.pfx",
+      "effect_scale": 1.0
+    }
+  },
+  "mesh_bounds": [
+    50,
+    50,
+    50
+  ],
+  "placement_size": [
+    100,
+    100
+  ],
+  "TEMP_texelinfo": 72.293
 }

--- a/pa/units/orbital/orbital_fabrication_bot/orbital_fabrication_bot.json
+++ b/pa/units/orbital/orbital_fabrication_bot/orbital_fabrication_bot.json
@@ -1,133 +1,299 @@
 {
-	"base_spec": "/pa/units/orbital/base_orbital/base_orbital.json",
-	"display_name": "!LOC(units:orbital_fabrication_bot.message):Orbital Fabrication Bot",
-	"description": "!LOC(units:advanced_fabricator_builds_orbital_satellites_and_ships.message):Advanced fabricator- Builds orbital satellites and ships.",
-	"max_health": 50,
-	"build_metal_cost": 1600,
-	"system_velocity_multiplier": 15.0,
-	"gravwell_velocity_multiplier": 6.0,
-	"spawn_layers": "WL_Orbital",
-	"buildable_types": "FabOrbBuild",
-	"unit_types": ["UNITTYPE_Orbital",
-	"UNITTYPE_Fabber",
-	"UNITTYPE_Construction",
-	"UNITTYPE_Mobile",
-	"UNITTYPE_Basic",
-	"UNITTYPE_FactoryBuild"],
-	"command_caps": ["ORDER_Move",
-	"ORDER_Patrol",
-	"ORDER_Build",
-	"ORDER_Repair",
-	"ORDER_Assist",
-	"ORDER_Use"],
-	"transportable": {
-		"size": 1
-	},
-	"attachable": {
-		"offsets": {
-			"root": [0,
-			0,
-			0]
-		}
-	},
-	"guard_layer": "WL_Orbital",
-	"navigation": {
-		"type": "orbital",
-		"acceleration": 10,
-		"brake": 10,
-		"move_speed": 20,
-		"turn_speed": 75,
-		"hover_time": -1.0,
-		"aggressive_behavior": "circle",
-		"aggressive_distance": 120,
-		"bank_factor": 10
-	},
-	"physics": {
-		"radius": 5,
-		"push_class": 15
-	},
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "radar",
-				"shape": "capsule",
-				"radius": 100
-			},
-			{
-				"layer": "orbital",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			}]
-		}
-	},
-	"model": {
-		"filename": "/pa/units/orbital/orbital_fabrication_bot/orbital_fabrication_bot.papa",
-		"animations": {
-			"open": "/pa/units/orbital/orbital_fabrication_bot/orbital_fabrication_bot_anim_open.papa",
-			"deploy": "/pa/units/orbital/orbital_fabrication_bot/orbital_fabrication_bot_anim_deploy.papa",
-			"closed": "/pa/units/orbital/orbital_fabrication_bot/orbital_fabrication_bot_anim_closed.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/orbital_fabrication_bot_anim_tree.json"
-	},
-	"tools": [{
-		"spec_id": "/pa/units/orbital/orbital_fabrication_bot/orbital_fabrication_bot_build_arm.json",
-		"aim_bone": "bone_shoulder"
-	}],
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/fab_orbital"
-		},
-		"died": {
-			"audio_cue": "/SE/Death/orbital"
-		}
-	},
-	"audio": {
-		"loops": {
-			"build": {
-				"cue": "/SE/Construction/Fab_contruction_beam_loop_orbital",
-				"flag": "build_target_changed",
-				"should_start_func": "has_build_target",
-				"should_stop_func": "no_build_target"
-			},
-			"move": {
-				"cue": "/SE/Movement/air/fab_air_loop",
-				"flag": "vel_changed",
-				"should_start_func": "is_moving",
-				"should_stop_func": "is_not_moving"
-			}
-		}
-	},
-	"fx_offsets": [{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "bone_nozzle",
-		"offset": [1.755,
-		0,
-		0],
-		"orientation": [0,
-		0,
-		-90]
-	}, {
-			"type" : "idle",
-			"bone" : "bone_leftSolarPanel",
-			"filename" : "/pa/effects/specs/lightblink_2_2_1.pfx",
-			"offset" : [12.2, 0, 0]
-		}, {
-			"type" : "idle",
-			"bone" : "bone_rightSolarPanel",
-			"filename" : "/pa/effects/specs/lightblink_2_2_2.pfx",
-			"offset" : [12, 0, 0]
-		}],
-	"mesh_bounds": [20,
-	10,
-	21],
-	"TEMP_texelinfo": 7.54279
+  "base_spec": "/pa/units/orbital/base_orbital/base_orbital.json",
+  "display_name": "!LOC(units:orbital_fabrication_bot.message):Orbital Fabrication Bot",
+  "description": "!LOC(units:advanced_fabricator_builds_orbital_satellites_and_ships.message):Advanced fabricator- Builds orbital satellites and ships.",
+  "max_health": 50,
+  "build_metal_cost": 1600,
+  "system_velocity_multiplier": 15.0,
+  "gravwell_velocity_multiplier": 6.0,
+  "spawn_layers": "WL_Orbital",
+  "buildable_types": "FabOrbBuild",
+  "unit_types": [
+    "UNITTYPE_Orbital",
+    "UNITTYPE_Fabber",
+    "UNITTYPE_Construction",
+    "UNITTYPE_Mobile",
+    "UNITTYPE_Basic",
+    "UNITTYPE_FactoryBuild"
+  ],
+  "command_caps": [
+    "ORDER_Move",
+    "ORDER_Patrol",
+    "ORDER_Build",
+    "ORDER_Reclaim",
+    "ORDER_Repair",
+    "ORDER_Assist",
+    "ORDER_Use"
+  ],
+  "attachable": {
+    "offsets": {
+      "root": [
+        0,
+        0,
+        0
+      ]
+    }
+  },
+  "guard_layer": "WL_Orbital",
+  "navigation": {
+    "type": "orbital",
+    "acceleration": 10,
+    "brake": 10,
+    "move_speed": 20,
+    "turn_speed": 75,
+    "hover_time": -1.0,
+    "aggressive_behavior": "circle",
+    "aggressive_distance": 120,
+    "bank_factor": 10
+  },
+  "physics": {
+    "radius": 5,
+    "push_class": 15
+  },
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "radar",
+          "shape": "capsule",
+          "radius": 100
+        },
+        {
+          "layer": "orbital",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 250
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        }
+      ]
+    }
+  },
+  "model": {
+    "filename": "/pa/units/orbital/orbital_fabrication_bot/orbital_fabrication_bot.papa",
+    "animations": {
+      "open": "/pa/units/orbital/orbital_fabrication_bot/orbital_fabrication_bot_anim_open.papa",
+      "deploy": "/pa/units/orbital/orbital_fabrication_bot/orbital_fabrication_bot_anim_deploy.papa",
+      "closed": "/pa/units/orbital/orbital_fabrication_bot/orbital_fabrication_bot_anim_closed.papa"
+    },
+    "animtree": "/pa/anim/anim_trees/orbital_fabrication_bot_anim_tree.json"
+  },
+  "tools": [
+    {
+      "spec_id": "/pa/units/orbital/orbital_fabrication_bot/orbital_fabrication_bot_build_arm.json",
+      "aim_bone": "bone_shoulder"
+    }
+  ],
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/fab_orbital"
+    },
+    "died": {
+      "audio_cue": "/SE/Death/orbital"
+    }
+  },
+  "audio": {
+    "loops": {
+      "build": {
+        "cue": "/SE/Construction/Fab_contruction_beam_loop_orbital",
+        "flag": "build_target_changed",
+        "should_start_func": "has_build_target",
+        "should_stop_func": "no_build_target"
+      },
+      "move": {
+        "cue": "/SE/Movement/air/fab_air_loop",
+        "flag": "vel_changed",
+        "should_start_func": "is_moving",
+        "should_stop_func": "is_not_moving"
+      }
+    }
+  },
+  "fx_offsets": [
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "bone_nozzle",
+      "offset": [
+        1.755,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        -90
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_leftSolarPanel",
+      "filename": "/pa/effects/specs/lightblink_2_2_1.pfx",
+      "offset": [
+        12.2,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_rightSolarPanel",
+      "filename": "/pa/effects/specs/lightblink_2_2_2.pfx",
+      "offset": [
+        12,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_rightSolarPanel",
+      "filename": "/pa/effects/specs/lightblink_2_2_2.pfx",
+      "offset": [
+        12,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_leftSolarPanel",
+      "filename": "/pa/effects/specs/lightblink_2_2_1.pfx",
+      "offset": [
+        12.2,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_leftSolarPanel",
+      "filename": "/pa/effects/specs/lightblink_2_2_1.pfx",
+      "offset": [
+        12.2,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_rightSolarPanel",
+      "filename": "/pa/effects/specs/lightblink_2_2_2.pfx",
+      "offset": [
+        12,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_rightSolarPanel",
+      "filename": "/pa/effects/specs/lightblink_2_2_2.pfx",
+      "offset": [
+        12,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_leftSolarPanel",
+      "filename": "/pa/effects/specs/lightblink_2_2_1.pfx",
+      "offset": [
+        12.2,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_leftSolarPanel",
+      "filename": "/pa/effects/specs/lightblink_2_2_1.pfx",
+      "offset": [
+        12.2,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_rightSolarPanel",
+      "filename": "/pa/effects/specs/lightblink_2_2_2.pfx",
+      "offset": [
+        12,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_rightSolarPanel",
+      "filename": "/pa/effects/specs/lightblink_2_2_2.pfx",
+      "offset": [
+        12,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_leftSolarPanel",
+      "filename": "/pa/effects/specs/lightblink_2_2_1.pfx",
+      "offset": [
+        12.2,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_leftSolarPanel",
+      "filename": "/pa/effects/specs/lightblink_2_2_1.pfx",
+      "offset": [
+        12.2,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_rightSolarPanel",
+      "filename": "/pa/effects/specs/lightblink_2_2_2.pfx",
+      "offset": [
+        12,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_rightSolarPanel",
+      "filename": "/pa/effects/specs/lightblink_2_2_2.pfx",
+      "offset": [
+        12,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_leftSolarPanel",
+      "filename": "/pa/effects/specs/lightblink_2_2_1.pfx",
+      "offset": [
+        12.2,
+        0,
+        0
+      ]
+    }
+  ],
+  "mesh_bounds": [
+    20,
+    10,
+    21
+  ],
+  "TEMP_texelinfo": 7.54279
 }

--- a/pa/units/orbital/orbital_factory/orbital_factory.json
+++ b/pa/units/orbital/orbital_factory/orbital_factory.json
@@ -1,160 +1,648 @@
 {
-	"base_spec": "/pa/units/orbital/base_orbital_structure/base_orbital_structure.json",
-	"display_name": "!LOC(units:orbital_factory.message):Orbital Factory",
-	"description": "!LOC(units:advanced_manufacturing_builds_orbital_satellites.message):Advanced manufacturing- Builds orbital satellites.",
-	"max_health": 15000,
-	"build_metal_cost": 5400,
-	"atrophy_rate": 90.0,
-	"atrophy_cool_down": 15.0,
-	"wreckage_health_frac": 0.0,
-	"buildable_types": "Orbital & FactoryBuild",
-	"enable_orbital_shell": true,
-	"rolloff_dirs": [[0,
-	1,
-	0],
-	[0,
-	-1,
-	0]],
-	"spawn_layers": "WL_Orbital",
-	"wait_to_rolloff_time": 0,
-	"factory_cooldown_time": 4,
-	"unit_types": ["UNITTYPE_Factory",
-	"UNITTYPE_Construction",
-	"UNITTYPE_Orbital",
-	"UNITTYPE_FabOrbBuild",
-	"UNITTYPE_Structure",
-	"UNITTYPE_Advanced",
-	"UNITTYPE_Important"],
-	"command_caps": ["ORDER_Move",
-	"ORDER_Patrol",
-	"ORDER_FactoryBuild",
-	"ORDER_Reclaim",
-	"ORDER_Repair",
-	"ORDER_Attack",
-	"ORDER_Assist"],
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "orbital",
-				"channel": "sight",
-				"shape": "sphere",
-				"radius": 100
-			}]
-		}
-	},
-	"physics": {
-		"radius": 20,
-		"push_class": 15,
-		"collision_layers": "WL_Orbital",
-		"ignore_gravity": true
-	},
-	"model": [{
-		"layer": "WL_Orbital",
-		"filename": "/pa/units/orbital/orbital_factory/orbital_factory.papa",
-		"animations": {
-			"build_start": "/pa/units/orbital/orbital_factory/orbital_factory_anim_start.papa",
-			"build_loop": "/pa/units/orbital/orbital_factory/orbital_factory_anim_build.papa",
-			"build_end": "/pa/units/orbital/orbital_factory/orbital_factory_anim_end.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/factory_anim_tree.json"
-	}],
-	"tools": [{
-		"spec_id": "/pa/units/orbital/orbital_factory/orbital_factory_build_arm.json",
-		"aim_bone": "bone_root"
-	}],
-	"events": {
-		"died": {
-			"audio_cue": "/SE/Death/orbital",
-			"effect_scale": 2.5
-		}
-	},
-	"audio": {
-		"loops": {
-			"build": {
-				"cue": "/SE/Construction/Factory_contruction_loop_orbital",
-				"flag": "build_target_changed",
-				"should_start_func": "has_build_target",
-				"should_stop_func": "no_build_target"
-			}
-		}
-	},
-	"fx_offsets" : [{
-			"type" : "build",
-			"filename" : "/pa/effects/specs/fab_spray.pfx",
-			"bone" : "bone_centerHalo",
-			"offset" : [17, 0, 0],
-			"orientation" : [0, 0, 90]
-		}, {
-			"type" : "build",
-			"filename" : "/pa/effects/specs/fab_spray.pfx",
-			"bone" : "bone_centerHalo",
-			"offset" : [-17, 0, 0],
-			"orientation" : [0, 0, -90]
-		}, {
-			"type" : "build",
-			"filename" : "/pa/effects/specs/fab_spray.pfx",
-			"bone" : "bone_frontHalo",
-			"offset" : [9.5, 0, 9.5],
-			"orientation" : [0, 0, 135]
-		}, {
-			"type" : "build",
-			"filename" : "/pa/effects/specs/fab_spray.pfx",
-			"bone" : "bone_frontHalo",
-			"offset" : [-9.5, 0, -9.5],
-			"orientation" : [0, 0, -135]
-		}, {
-			"type" : "build",
-			"filename" : "/pa/effects/specs/fab_spray.pfx",
-			"bone" : "bone_backHalo",
-			"offset" : [9.5, 0, 9.5],
-			"orientation" : [0, 0, 135]
-		}, {
-			"type" : "build",
-			"filename" : "/pa/effects/specs/fab_spray.pfx",
-			"bone" : "bone_backHalo",
-			"offset" : [-9.5, 0, -9.5],
-			"orientation" : [0, 0, -135]
-		},{
-			"label" : "Corner Antenna 1",
-			"type" : "idle",
-			"bone" : "bone_frontArms",
-			"filename" : "/pa/effects/specs/light_1_4_3_4.pfx",
-			"offset" : [19.2, -38, 0]
-		},{
-			"label" : "Corner Antenna 2",
-			"type" : "idle",
-			"bone" : "bone_backArms",
-			"filename" : "/pa/effects/specs/light_1_4_1_4.pfx",
-			"offset" : [19.2, -38, 0]
-		},{
-			"label" : "Corner Antenna 3",
-			"type" : "idle",
-			"bone" : "bone_backArms",
-			"filename" : "/pa/effects/specs/light_1_4_2_4.pfx",
-			"offset" : [-19.2, -38, 0]
-		},{
-			"label" : "Corner Antenna 4",
-			"type" : "idle",
-			"bone" : "bone_frontArms",
-			"filename" : "/pa/effects/specs/light_1_4_4_4.pfx",
-			"offset" : [-19.2, -38, 0]
-		},{
-			"label" : "Building Antennas",
-			"type" : "build",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/orbital/orbital_factory/orbital_factory_build_light.pfx"
-		},{
-			"label" : "Bottom Tri Antenna Light",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/orbital/orbital_factory/orbital_factory_bottom_light.pfx"
-		}
-	],
-	"mesh_bounds": [45,
-	40,
-	24],
-	"placement_size": [100,
-	100],
-	"area_build_separation": 7,
-	"TEMP_texelinfo": 65.6074
+  "base_spec": "/pa/units/orbital/base_orbital_structure/base_orbital_structure.json",
+  "display_name": "!LOC(units:orbital_factory.message):Orbital Factory",
+  "description": "!LOC(units:advanced_manufacturing_builds_orbital_satellites.message):Advanced manufacturing- Builds orbital satellites.",
+  "max_health": 9000,
+  "build_metal_cost": 5400,
+  "atrophy_rate": 90.0,
+  "atrophy_cool_down": 15.0,
+  "wreckage_health_frac": 0.0,
+  "buildable_types": "Orbital & FactoryBuild",
+  "enable_orbital_shell": true,
+  "rolloff_dirs": [
+    [
+      0,
+      1,
+      0
+    ],
+    [
+      0,
+      -1,
+      0
+    ]
+  ],
+  "spawn_layers": "WL_Orbital",
+  "wait_to_rolloff_time": 0,
+  "factory_cooldown_time": 4,
+  "unit_types": [
+    "UNITTYPE_Factory",
+    "UNITTYPE_Construction",
+    "UNITTYPE_Orbital",
+    "UNITTYPE_FabOrbBuild",
+    "UNITTYPE_Structure",
+    "UNITTYPE_Advanced",
+    "UNITTYPE_Important"
+  ],
+  "command_caps": [
+    "ORDER_Move",
+    "ORDER_Patrol",
+    "ORDER_FactoryBuild",
+    "ORDER_Reclaim",
+    "ORDER_Repair",
+    "ORDER_Attack",
+    "ORDER_Assist"
+  ],
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "orbital",
+          "channel": "sight",
+          "shape": "sphere",
+          "radius": 250
+        }
+      ]
+    }
+  },
+  "physics": {
+    "radius": 20,
+    "push_class": 15,
+    "collision_layers": "WL_Orbital",
+    "ignore_gravity": true
+  },
+  "model": [
+    {
+      "layer": "WL_Orbital",
+      "filename": "/pa/units/orbital/orbital_factory/orbital_factory.papa",
+      "animations": {
+        "build_start": "/pa/units/orbital/orbital_factory/orbital_factory_anim_start.papa",
+        "build_loop": "/pa/units/orbital/orbital_factory/orbital_factory_anim_build.papa",
+        "build_end": "/pa/units/orbital/orbital_factory/orbital_factory_anim_end.papa"
+      },
+      "animtree": "/pa/anim/anim_trees/factory_anim_tree.json"
+    }
+  ],
+  "tools": [
+    {
+      "spec_id": "/pa/units/orbital/orbital_factory/orbital_factory_build_arm.json",
+      "aim_bone": "bone_root"
+    }
+  ],
+  "events": {
+    "died": {
+      "audio_cue": "/SE/Death/orbital",
+      "effect_scale": 2.5
+    }
+  },
+  "audio": {
+    "loops": {
+      "build": {
+        "cue": "/SE/Construction/Factory_contruction_loop_orbital",
+        "flag": "build_target_changed",
+        "should_start_func": "has_build_target",
+        "should_stop_func": "no_build_target"
+      }
+    }
+  },
+  "fx_offsets": [
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "bone_centerHalo",
+      "offset": [
+        17,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        90
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "bone_centerHalo",
+      "offset": [
+        -17,
+        0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        -90
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "bone_frontHalo",
+      "offset": [
+        9.5,
+        0,
+        9.5
+      ],
+      "orientation": [
+        0,
+        0,
+        135
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "bone_frontHalo",
+      "offset": [
+        -9.5,
+        0,
+        -9.5
+      ],
+      "orientation": [
+        0,
+        0,
+        -135
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "bone_backHalo",
+      "offset": [
+        9.5,
+        0,
+        9.5
+      ],
+      "orientation": [
+        0,
+        0,
+        135
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "bone_backHalo",
+      "offset": [
+        -9.5,
+        0,
+        -9.5
+      ],
+      "orientation": [
+        0,
+        0,
+        -135
+      ]
+    },
+    {
+      "label": "Corner Antenna 1",
+      "type": "idle",
+      "bone": "bone_frontArms",
+      "filename": "/pa/effects/specs/light_1_4_3_4.pfx",
+      "offset": [
+        19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 2",
+      "type": "idle",
+      "bone": "bone_backArms",
+      "filename": "/pa/effects/specs/light_1_4_1_4.pfx",
+      "offset": [
+        19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 3",
+      "type": "idle",
+      "bone": "bone_backArms",
+      "filename": "/pa/effects/specs/light_1_4_2_4.pfx",
+      "offset": [
+        -19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 4",
+      "type": "idle",
+      "bone": "bone_frontArms",
+      "filename": "/pa/effects/specs/light_1_4_4_4.pfx",
+      "offset": [
+        -19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Building Antennas",
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_factory/orbital_factory_build_light.pfx"
+    },
+    {
+      "label": "Bottom Tri Antenna Light",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_factory/orbital_factory_bottom_light.pfx"
+    },
+    {
+      "label": "Bottom Tri Antenna Light",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_factory/orbital_factory_bottom_light.pfx"
+    },
+    {
+      "label": "Building Antennas",
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_factory/orbital_factory_build_light.pfx"
+    },
+    {
+      "label": "Corner Antenna 4",
+      "type": "idle",
+      "bone": "bone_frontArms",
+      "filename": "/pa/effects/specs/light_1_4_4_4.pfx",
+      "offset": [
+        -19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 3",
+      "type": "idle",
+      "bone": "bone_backArms",
+      "filename": "/pa/effects/specs/light_1_4_2_4.pfx",
+      "offset": [
+        -19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 2",
+      "type": "idle",
+      "bone": "bone_backArms",
+      "filename": "/pa/effects/specs/light_1_4_1_4.pfx",
+      "offset": [
+        19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 1",
+      "type": "idle",
+      "bone": "bone_frontArms",
+      "filename": "/pa/effects/specs/light_1_4_3_4.pfx",
+      "offset": [
+        19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 1",
+      "type": "idle",
+      "bone": "bone_frontArms",
+      "filename": "/pa/effects/specs/light_1_4_3_4.pfx",
+      "offset": [
+        19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 2",
+      "type": "idle",
+      "bone": "bone_backArms",
+      "filename": "/pa/effects/specs/light_1_4_1_4.pfx",
+      "offset": [
+        19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 3",
+      "type": "idle",
+      "bone": "bone_backArms",
+      "filename": "/pa/effects/specs/light_1_4_2_4.pfx",
+      "offset": [
+        -19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 4",
+      "type": "idle",
+      "bone": "bone_frontArms",
+      "filename": "/pa/effects/specs/light_1_4_4_4.pfx",
+      "offset": [
+        -19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Building Antennas",
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_factory/orbital_factory_build_light.pfx"
+    },
+    {
+      "label": "Bottom Tri Antenna Light",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_factory/orbital_factory_bottom_light.pfx"
+    },
+    {
+      "label": "Bottom Tri Antenna Light",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_factory/orbital_factory_bottom_light.pfx"
+    },
+    {
+      "label": "Building Antennas",
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_factory/orbital_factory_build_light.pfx"
+    },
+    {
+      "label": "Corner Antenna 4",
+      "type": "idle",
+      "bone": "bone_frontArms",
+      "filename": "/pa/effects/specs/light_1_4_4_4.pfx",
+      "offset": [
+        -19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 3",
+      "type": "idle",
+      "bone": "bone_backArms",
+      "filename": "/pa/effects/specs/light_1_4_2_4.pfx",
+      "offset": [
+        -19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 2",
+      "type": "idle",
+      "bone": "bone_backArms",
+      "filename": "/pa/effects/specs/light_1_4_1_4.pfx",
+      "offset": [
+        19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 1",
+      "type": "idle",
+      "bone": "bone_frontArms",
+      "filename": "/pa/effects/specs/light_1_4_3_4.pfx",
+      "offset": [
+        19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 1",
+      "type": "idle",
+      "bone": "bone_frontArms",
+      "filename": "/pa/effects/specs/light_1_4_3_4.pfx",
+      "offset": [
+        19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 2",
+      "type": "idle",
+      "bone": "bone_backArms",
+      "filename": "/pa/effects/specs/light_1_4_1_4.pfx",
+      "offset": [
+        19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 3",
+      "type": "idle",
+      "bone": "bone_backArms",
+      "filename": "/pa/effects/specs/light_1_4_2_4.pfx",
+      "offset": [
+        -19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 4",
+      "type": "idle",
+      "bone": "bone_frontArms",
+      "filename": "/pa/effects/specs/light_1_4_4_4.pfx",
+      "offset": [
+        -19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Building Antennas",
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_factory/orbital_factory_build_light.pfx"
+    },
+    {
+      "label": "Bottom Tri Antenna Light",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_factory/orbital_factory_bottom_light.pfx"
+    },
+    {
+      "label": "Bottom Tri Antenna Light",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_factory/orbital_factory_bottom_light.pfx"
+    },
+    {
+      "label": "Building Antennas",
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_factory/orbital_factory_build_light.pfx"
+    },
+    {
+      "label": "Corner Antenna 4",
+      "type": "idle",
+      "bone": "bone_frontArms",
+      "filename": "/pa/effects/specs/light_1_4_4_4.pfx",
+      "offset": [
+        -19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 3",
+      "type": "idle",
+      "bone": "bone_backArms",
+      "filename": "/pa/effects/specs/light_1_4_2_4.pfx",
+      "offset": [
+        -19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 2",
+      "type": "idle",
+      "bone": "bone_backArms",
+      "filename": "/pa/effects/specs/light_1_4_1_4.pfx",
+      "offset": [
+        19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 1",
+      "type": "idle",
+      "bone": "bone_frontArms",
+      "filename": "/pa/effects/specs/light_1_4_3_4.pfx",
+      "offset": [
+        19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 1",
+      "type": "idle",
+      "bone": "bone_frontArms",
+      "filename": "/pa/effects/specs/light_1_4_3_4.pfx",
+      "offset": [
+        19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 2",
+      "type": "idle",
+      "bone": "bone_backArms",
+      "filename": "/pa/effects/specs/light_1_4_1_4.pfx",
+      "offset": [
+        19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 3",
+      "type": "idle",
+      "bone": "bone_backArms",
+      "filename": "/pa/effects/specs/light_1_4_2_4.pfx",
+      "offset": [
+        -19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 4",
+      "type": "idle",
+      "bone": "bone_frontArms",
+      "filename": "/pa/effects/specs/light_1_4_4_4.pfx",
+      "offset": [
+        -19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Building Antennas",
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_factory/orbital_factory_build_light.pfx"
+    },
+    {
+      "label": "Bottom Tri Antenna Light",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_factory/orbital_factory_bottom_light.pfx"
+    },
+    {
+      "label": "Bottom Tri Antenna Light",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_factory/orbital_factory_bottom_light.pfx"
+    },
+    {
+      "label": "Building Antennas",
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_factory/orbital_factory_build_light.pfx"
+    },
+    {
+      "label": "Corner Antenna 4",
+      "type": "idle",
+      "bone": "bone_frontArms",
+      "filename": "/pa/effects/specs/light_1_4_4_4.pfx",
+      "offset": [
+        -19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 3",
+      "type": "idle",
+      "bone": "bone_backArms",
+      "filename": "/pa/effects/specs/light_1_4_2_4.pfx",
+      "offset": [
+        -19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 2",
+      "type": "idle",
+      "bone": "bone_backArms",
+      "filename": "/pa/effects/specs/light_1_4_1_4.pfx",
+      "offset": [
+        19.2,
+        -38,
+        0
+      ]
+    },
+    {
+      "label": "Corner Antenna 1",
+      "type": "idle",
+      "bone": "bone_frontArms",
+      "filename": "/pa/effects/specs/light_1_4_3_4.pfx",
+      "offset": [
+        19.2,
+        -38,
+        0
+      ]
+    }
+  ],
+  "mesh_bounds": [
+    45,
+    40,
+    24
+  ],
+  "placement_size": [
+    100,
+    100
+  ],
+  "area_build_separation": 7,
+  "TEMP_texelinfo": 65.6074
 }

--- a/pa/units/orbital/orbital_fighter/orbital_fighter.json
+++ b/pa/units/orbital/orbital_fighter/orbital_fighter.json
@@ -1,123 +1,554 @@
 {
-	"base_spec": "/pa/units/orbital/base_orbital/base_orbital.json",
-	"display_name": "!LOC(units:avenger.message):Avenger",
-	"description": "!LOC(units:orbital_fighter_fast_moving_orbital_fighter_for_offense_and_defense.message):Orbital fighter- Fast moving orbital fighter for offense and defense.",
-	"build_metal_cost": 800,
-	"max_health": 250,
-	"gravwell_velocity_multiplier": 6.0,
-	"wreckage_health_frac": 0.0,
-	"spawn_layers": "WL_Orbital",
-	"attachable": {
-		"offsets": {
-			"root": [0,
-			0,
-			0]
-		}
-	},
-	"unit_types": ["UNITTYPE_Mobile",
-	"UNITTYPE_Offense",
-	"UNITTYPE_Orbital",
-	"UNITTYPE_Fighter",
-	"UNITTYPE_Basic",
-	"UNITTYPE_FactoryBuild"],
-	"command_caps": ["ORDER_Move",
-	"ORDER_Patrol",
-	"ORDER_Attack",
-	"ORDER_Assist"],
-	"guard_layer": "WL_Orbital",
-	"navigation": {
-		"type": "orbital",
-		"acceleration": 50,
-		"brake": 50,
-		"move_speed": 50,
-		"turn_speed": 90,
-		"circle_min_time": 2,
-		"circle_max_time": 4,
-		"hover_time": -1.0,
-		"aggressive_behavior": "circle",
-		"aggressive_distance": 150,
-		"bank_factor": 1
-	},
-	"physics": {
-		"radius": 5,
-		"push_class": 15,
-		"gravity_scalar": 0.001
-	},
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "orbital",
-				"channel": "sight",
-				"shape": "sphere",
-				"radius": 250
-			}]
-		}
-	},
-	"model": {
-		"filename": "/pa/units/orbital/orbital_fighter/orbital_fighter.papa",
-		"animations": {
-			"deploy": "/pa/units/orbital/orbital_fighter/orbital_fighter_anim_deploy.papa",
-			"closed": "/pa/units/orbital/orbital_fighter/orbital_fighter_anim_closed.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/orbital_fighter_anim_tree.json"
-	},
-	"tools": [{
-		"spec_id": "/pa/units/orbital/orbital_fighter/orbital_fighter_tool_weapon.json",
-		"aim_bone": "bone_body",
-		"muzzle_bone": "bone_recoil01"
-	}],
-	"fx_offsets" : [{
-			"type" : "moving",
-			"filename" : "/pa/units/air/gunship/gunship_jets.pfx",
-			"bone" : "bone_body",
-			"offset" : [0, 8.9, 0],
-			"orientation" : [0, 0, 0]
-		},{
-			"label" : "Antenna",
-			"type" : "build",
-			"bone" : "bone_body",
-			"filename" : "/pa/effects/specs/light_2_4_1_2.pfx",
-			"offset" : [0, 0.15, 3.9]
-		},{
-			"label" : "Left Wing",
-			"type" : "idle",
-			"bone" : "bone_wingTip",
-			"filename" : "/pa/effects/specs/light_2_4_3_2.pfx",
-			"offset" : [-0.9, 3.2, -2.6]
-		},{
-			"label" : "Left Wing - Moving",
-			"type" : "moving",
-			"bone" : "bone_wingTip",
-			"filename" : "/pa/effects/specs/light_2_4_4_2.pfx",
-			"offset" : [-0.9, 3.2, -2.6]
-		},{
-			"label" : "Solar Wing",
-			"type" : "idle",
-			"bone" : "bone_solarPanel",
-			"filename" : "/pa/effects/specs/light_2_4_2_2.pfx",
-			"offset" : [-0.3, -8.5,-1.3]
-		},		{
-			"label" : "Solar Wing - Moving",
-			"type" : "moving",
-			"bone" : "bone_solarPanel",
-			"filename" : "/pa/effects/specs/light_2_4_1_2.pfx",
-			"offset" : [-0.3, -8.5,-1.3]
-		}
-	],
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/orbital"
-		},
-		"fired": {
-			"audio_cue": "/SE/Weapons/orb/orb_fighter_fire",
-			"effect_spec": "/pa/effects/specs/default_muzzle_flash.pfx socket_muzzle"
-		},
-		"died": {
-			"audio_cue": "/SE/Death/orbital"
-		}
-	},
-	"mesh_bounds": [20,
-	16,
-	5.3],
-	"TEMP_texelinfo": 17.7177
+  "base_spec": "/pa/units/orbital/base_orbital/base_orbital.json",
+  "display_name": "!LOC(units:avenger.message):Avenger",
+  "description": "!LOC(units:orbital_fighter_fast_moving_orbital_fighter_for_offense_and_defense.message):Orbital fighter- Fast moving orbital fighter for offense and defense.",
+  "build_metal_cost": 800,
+  "max_health": 250,
+  "gravwell_velocity_multiplier": 6.0,
+  "wreckage_health_frac": 0.0,
+  "spawn_layers": "WL_Orbital",
+  "attachable": {
+    "offsets": {
+      "root": [
+        0,
+        0,
+        0
+      ]
+    }
+  },
+  "unit_types": [
+    "UNITTYPE_Mobile",
+    "UNITTYPE_Offense",
+    "UNITTYPE_Orbital",
+    "UNITTYPE_Fighter",
+    "UNITTYPE_Basic",
+    "UNITTYPE_FactoryBuild"
+  ],
+  "command_caps": [
+    "ORDER_Move",
+    "ORDER_Patrol",
+    "ORDER_Attack",
+    "ORDER_Assist"
+  ],
+  "guard_layer": "WL_Orbital",
+  "navigation": {
+    "type": "orbital",
+    "acceleration": 50,
+    "brake": 50,
+    "move_speed": 50,
+    "turn_speed": 90,
+    "circle_min_time": 2,
+    "circle_max_time": 4,
+    "hover_time": -1.0,
+    "aggressive_behavior": "circle",
+    "aggressive_distance": 150,
+    "bank_factor": 1
+  },
+  "physics": {
+    "radius": 5,
+    "push_class": 15,
+    "gravity_scalar": 0.001
+  },
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "orbital",
+          "channel": "sight",
+          "shape": "sphere",
+          "radius": 400
+        }
+      ]
+    }
+  },
+  "model": {
+    "filename": "/pa/units/orbital/orbital_fighter/orbital_fighter.papa",
+    "animations": {
+      "deploy": "/pa/units/orbital/orbital_fighter/orbital_fighter_anim_deploy.papa",
+      "closed": "/pa/units/orbital/orbital_fighter/orbital_fighter_anim_closed.papa"
+    },
+    "animtree": "/pa/anim/anim_trees/orbital_fighter_anim_tree.json"
+  },
+  "tools": [
+    {
+      "spec_id": "/pa/units/orbital/orbital_fighter/orbital_fighter_tool_weapon.json",
+      "aim_bone": "bone_body",
+      "muzzle_bone": "bone_recoil01"
+    }
+  ],
+  "fx_offsets": [
+    {
+      "type": "moving",
+      "filename": "/pa/units/air/gunship/gunship_jets.pfx",
+      "bone": "bone_body",
+      "offset": [
+        0,
+        8.9,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "label": "Antenna",
+      "type": "build",
+      "bone": "bone_body",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        0,
+        0.15,
+        3.9
+      ]
+    },
+    {
+      "label": "Left Wing",
+      "type": "idle",
+      "bone": "bone_wingTip",
+      "filename": "/pa/effects/specs/light_2_4_3_2.pfx",
+      "offset": [
+        -0.9,
+        3.2,
+        -2.6
+      ]
+    },
+    {
+      "label": "Left Wing - Moving",
+      "type": "moving",
+      "bone": "bone_wingTip",
+      "filename": "/pa/effects/specs/light_2_4_4_2.pfx",
+      "offset": [
+        -0.9,
+        3.2,
+        -2.6
+      ]
+    },
+    {
+      "label": "Solar Wing",
+      "type": "idle",
+      "bone": "bone_solarPanel",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -0.3,
+        -8.5,
+        -1.3
+      ]
+    },
+    {
+      "label": "Solar Wing - Moving",
+      "type": "moving",
+      "bone": "bone_solarPanel",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -0.3,
+        -8.5,
+        -1.3
+      ]
+    },
+    {
+      "label": "Solar Wing - Moving",
+      "type": "moving",
+      "bone": "bone_solarPanel",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -0.3,
+        -8.5,
+        -1.3
+      ]
+    },
+    {
+      "label": "Solar Wing",
+      "type": "idle",
+      "bone": "bone_solarPanel",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -0.3,
+        -8.5,
+        -1.3
+      ]
+    },
+    {
+      "label": "Left Wing - Moving",
+      "type": "moving",
+      "bone": "bone_wingTip",
+      "filename": "/pa/effects/specs/light_2_4_4_2.pfx",
+      "offset": [
+        -0.9,
+        3.2,
+        -2.6
+      ]
+    },
+    {
+      "label": "Left Wing",
+      "type": "idle",
+      "bone": "bone_wingTip",
+      "filename": "/pa/effects/specs/light_2_4_3_2.pfx",
+      "offset": [
+        -0.9,
+        3.2,
+        -2.6
+      ]
+    },
+    {
+      "label": "Antenna",
+      "type": "build",
+      "bone": "bone_body",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        0,
+        0.15,
+        3.9
+      ]
+    },
+    {
+      "label": "Antenna",
+      "type": "build",
+      "bone": "bone_body",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        0,
+        0.15,
+        3.9
+      ]
+    },
+    {
+      "label": "Left Wing",
+      "type": "idle",
+      "bone": "bone_wingTip",
+      "filename": "/pa/effects/specs/light_2_4_3_2.pfx",
+      "offset": [
+        -0.9,
+        3.2,
+        -2.6
+      ]
+    },
+    {
+      "label": "Left Wing - Moving",
+      "type": "moving",
+      "bone": "bone_wingTip",
+      "filename": "/pa/effects/specs/light_2_4_4_2.pfx",
+      "offset": [
+        -0.9,
+        3.2,
+        -2.6
+      ]
+    },
+    {
+      "label": "Solar Wing",
+      "type": "idle",
+      "bone": "bone_solarPanel",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -0.3,
+        -8.5,
+        -1.3
+      ]
+    },
+    {
+      "label": "Solar Wing - Moving",
+      "type": "moving",
+      "bone": "bone_solarPanel",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -0.3,
+        -8.5,
+        -1.3
+      ]
+    },
+    {
+      "label": "Solar Wing - Moving",
+      "type": "moving",
+      "bone": "bone_solarPanel",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -0.3,
+        -8.5,
+        -1.3
+      ]
+    },
+    {
+      "label": "Solar Wing",
+      "type": "idle",
+      "bone": "bone_solarPanel",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -0.3,
+        -8.5,
+        -1.3
+      ]
+    },
+    {
+      "label": "Left Wing - Moving",
+      "type": "moving",
+      "bone": "bone_wingTip",
+      "filename": "/pa/effects/specs/light_2_4_4_2.pfx",
+      "offset": [
+        -0.9,
+        3.2,
+        -2.6
+      ]
+    },
+    {
+      "label": "Left Wing",
+      "type": "idle",
+      "bone": "bone_wingTip",
+      "filename": "/pa/effects/specs/light_2_4_3_2.pfx",
+      "offset": [
+        -0.9,
+        3.2,
+        -2.6
+      ]
+    },
+    {
+      "label": "Antenna",
+      "type": "build",
+      "bone": "bone_body",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        0,
+        0.15,
+        3.9
+      ]
+    },
+    {
+      "label": "Antenna",
+      "type": "build",
+      "bone": "bone_body",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        0,
+        0.15,
+        3.9
+      ]
+    },
+    {
+      "label": "Left Wing",
+      "type": "idle",
+      "bone": "bone_wingTip",
+      "filename": "/pa/effects/specs/light_2_4_3_2.pfx",
+      "offset": [
+        -0.9,
+        3.2,
+        -2.6
+      ]
+    },
+    {
+      "label": "Left Wing - Moving",
+      "type": "moving",
+      "bone": "bone_wingTip",
+      "filename": "/pa/effects/specs/light_2_4_4_2.pfx",
+      "offset": [
+        -0.9,
+        3.2,
+        -2.6
+      ]
+    },
+    {
+      "label": "Solar Wing",
+      "type": "idle",
+      "bone": "bone_solarPanel",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -0.3,
+        -8.5,
+        -1.3
+      ]
+    },
+    {
+      "label": "Solar Wing - Moving",
+      "type": "moving",
+      "bone": "bone_solarPanel",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -0.3,
+        -8.5,
+        -1.3
+      ]
+    },
+    {
+      "label": "Solar Wing - Moving",
+      "type": "moving",
+      "bone": "bone_solarPanel",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -0.3,
+        -8.5,
+        -1.3
+      ]
+    },
+    {
+      "label": "Solar Wing",
+      "type": "idle",
+      "bone": "bone_solarPanel",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -0.3,
+        -8.5,
+        -1.3
+      ]
+    },
+    {
+      "label": "Left Wing - Moving",
+      "type": "moving",
+      "bone": "bone_wingTip",
+      "filename": "/pa/effects/specs/light_2_4_4_2.pfx",
+      "offset": [
+        -0.9,
+        3.2,
+        -2.6
+      ]
+    },
+    {
+      "label": "Left Wing",
+      "type": "idle",
+      "bone": "bone_wingTip",
+      "filename": "/pa/effects/specs/light_2_4_3_2.pfx",
+      "offset": [
+        -0.9,
+        3.2,
+        -2.6
+      ]
+    },
+    {
+      "label": "Antenna",
+      "type": "build",
+      "bone": "bone_body",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        0,
+        0.15,
+        3.9
+      ]
+    },
+    {
+      "label": "Antenna",
+      "type": "build",
+      "bone": "bone_body",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        0,
+        0.15,
+        3.9
+      ]
+    },
+    {
+      "label": "Left Wing",
+      "type": "idle",
+      "bone": "bone_wingTip",
+      "filename": "/pa/effects/specs/light_2_4_3_2.pfx",
+      "offset": [
+        -0.9,
+        3.2,
+        -2.6
+      ]
+    },
+    {
+      "label": "Left Wing - Moving",
+      "type": "moving",
+      "bone": "bone_wingTip",
+      "filename": "/pa/effects/specs/light_2_4_4_2.pfx",
+      "offset": [
+        -0.9,
+        3.2,
+        -2.6
+      ]
+    },
+    {
+      "label": "Solar Wing",
+      "type": "idle",
+      "bone": "bone_solarPanel",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -0.3,
+        -8.5,
+        -1.3
+      ]
+    },
+    {
+      "label": "Solar Wing - Moving",
+      "type": "moving",
+      "bone": "bone_solarPanel",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -0.3,
+        -8.5,
+        -1.3
+      ]
+    },
+    {
+      "label": "Solar Wing - Moving",
+      "type": "moving",
+      "bone": "bone_solarPanel",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -0.3,
+        -8.5,
+        -1.3
+      ]
+    },
+    {
+      "label": "Solar Wing",
+      "type": "idle",
+      "bone": "bone_solarPanel",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -0.3,
+        -8.5,
+        -1.3
+      ]
+    },
+    {
+      "label": "Left Wing - Moving",
+      "type": "moving",
+      "bone": "bone_wingTip",
+      "filename": "/pa/effects/specs/light_2_4_4_2.pfx",
+      "offset": [
+        -0.9,
+        3.2,
+        -2.6
+      ]
+    },
+    {
+      "label": "Left Wing",
+      "type": "idle",
+      "bone": "bone_wingTip",
+      "filename": "/pa/effects/specs/light_2_4_3_2.pfx",
+      "offset": [
+        -0.9,
+        3.2,
+        -2.6
+      ]
+    },
+    {
+      "label": "Antenna",
+      "type": "build",
+      "bone": "bone_body",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        0,
+        0.15,
+        3.9
+      ]
+    }
+  ],
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/orbital"
+    },
+    "fired": {
+      "audio_cue": "/SE/Weapons/orb/orb_fighter_fire",
+      "effect_spec": "/pa/effects/specs/default_muzzle_flash.pfx socket_muzzle"
+    },
+    "died": {
+      "audio_cue": "/SE/Death/orbital"
+    }
+  },
+  "mesh_bounds": [
+    20,
+    16,
+    5.3
+  ],
+  "TEMP_texelinfo": 17.7177
 }

--- a/pa/units/orbital/orbital_laser/orbital_laser.json
+++ b/pa/units/orbital/orbital_laser/orbital_laser.json
@@ -1,114 +1,147 @@
 {
-	"base_spec": "/pa/units/orbital/base_orbital/base_orbital.json",
-	"display_name": "!LOC(units:sxx_1304_laser_platform.message):SXX-1304 Laser Platform",
-	"description": "!LOC(units:orbital_laser_platform_rains_death_from_above.message):Orbital laser platform- Rains death from above.",
-	"max_health": 1600,
-	"build_metal_cost": 6000,
-	"spawn_layers": "WL_Orbital",
-	"gravwell_velocity_multiplier": 6.0,
-	"attachable": {
-		"offsets": {
-			"root": [0,
-			0,
-			0]
-		}
-	},
-	"unit_types": ["UNITTYPE_Mobile",
-	"UNITTYPE_Offense",
-	"UNITTYPE_Orbital",
-	"UNITTYPE_LaserPlatform",
-	"UNITTYPE_Advanced",
-	"UNITTYPE_FactoryBuild"],
-	"command_caps": ["ORDER_Move",
-	"ORDER_Patrol",
-	"ORDER_Attack"],
-	"guard_layer": "WL_AnySurface",
-	"navigation": {
-		"type": "orbital",
-		"acceleration": 25,
-		"brake": 25,
-		"move_speed": 25,
-		"turn_speed": 90,
-		"hover_time": -1.0
-	},
-	"physics": {
-		"radius": 10,
-		"push_class": 15,
-		"gravity_scalar": 0.001
-	},
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			},
-			{
-				"layer": "orbital",
-				"channel": "sight",
-				"shape": "sphere",
-				"radius": 100
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 100
-			}]
-		}
-	},
-	"model": {
-		"filename": "/pa/units/orbital/orbital_laser/orbital_laser.papa",
-		"animations": {
-			"open": "/pa/units/orbital/orbital_laser/orbital_laser_anim_open.papa",
-			"closed": "/pa/units/orbital/orbital_laser/orbital_laser_anim_closed.papa",
-			"deploy": "/pa/units/orbital/orbital_laser/orbital_laser_anim_deploy.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/orbital_laser_anim_tree.json"
-	},
-	"tools": [{
-		"spec_id": "/pa/units/orbital/orbital_laser/orbital_laser_tool_weapon.json",
-		"aim_bone": "bone_recoil",
-		"muzzle_bone": "socket_muzzle"
-	}],
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/orbital"
-		},
-		"fired": {
-			"audio_cue": "/SE/Weapons/orb/orb_ssx_laser_fire",
-			"effect_spec": "/pa/units/orbital/orbital_laser/orbital_laser_muzzle_flash.pfx socket_muzzle",
-			"effect_scale": 3
-		},
-		"died": {
-			"audio_cue": "/SE/Death/orbital",
-			"effect_scale": 2
-		}
-	},
-	"fx_offsets": [{
-		"type" : "idle",
-			"bone" : "bone_rotator",
-			"filename" : "/pa/effects/specs/light_2_4_1.pfx",
-			"offset" : [8.45, 1, -3.5]
-		},{
-			"type" : "idle",
-			"bone" : "bone_rotator",
-			"filename" : "/pa/effects/specs/light_2_4_1.pfx",
-			"offset" : [-8.45, -1, -3.5]
-		},{
-			"type" : "idle",
-			"bone" : "bone_rotator",
-			"filename" : "/pa/effects/specs/lightblink_1_4_1.pfx",
-			"offset" : [7.6, 1, -1.3]
-		},{
-			"type" : "idle",
-			"bone" : "bone_rotator",
-			"filename" : "/pa/effects/specs/lightblink_1_4_1.pfx",
-			"offset" : [-7.6, -1, -1.3]
-		}],
-	"mesh_bounds": [38,
-	38,
-	40],
-	"TEMP_texelinfo": 31.6199
+  "base_spec": "/pa/units/orbital/base_orbital/base_orbital.json",
+  "display_name": "!LOC(units:sxx_1304_laser_platform.message):SXX-1304 Laser Platform",
+  "description": "!LOC(units:orbital_laser_platform_rains_death_from_above.message):Orbital laser platform- Rains death from above.",
+  "max_health": 1600,
+  "build_metal_cost": 6000,
+  "spawn_layers": "WL_Orbital",
+  "gravwell_velocity_multiplier": 6.0,
+  "attachable": {
+    "offsets": {
+      "root": [
+        0,
+        0,
+        0
+      ]
+    }
+  },
+  "unit_types": [
+    "UNITTYPE_Mobile",
+    "UNITTYPE_Offense",
+    "UNITTYPE_Orbital",
+    "UNITTYPE_LaserPlatform",
+    "UNITTYPE_Advanced",
+    "UNITTYPE_FactoryBuild"
+  ],
+  "command_caps": [
+    "ORDER_Move",
+    "ORDER_Patrol",
+    "ORDER_Attack"
+  ],
+  "guard_layer": "WL_AnySurface",
+  "navigation": {
+    "type": "orbital",
+    "acceleration": 25,
+    "brake": 25,
+    "move_speed": 25,
+    "turn_speed": 90,
+    "hover_time": -1.0
+  },
+  "physics": {
+    "radius": 10,
+    "push_class": 15,
+    "gravity_scalar": 0.001
+  },
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        },
+        {
+          "layer": "orbital",
+          "channel": "sight",
+          "shape": "sphere",
+          "radius": 100
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 100
+        }
+      ]
+    }
+  },
+  "model": {
+    "filename": "/pa/units/orbital/orbital_laser/orbital_laser.papa",
+    "animations": {
+      "open": "/pa/units/orbital/orbital_laser/orbital_laser_anim_open.papa",
+      "closed": "/pa/units/orbital/orbital_laser/orbital_laser_anim_closed.papa",
+      "deploy": "/pa/units/orbital/orbital_laser/orbital_laser_anim_deploy.papa"
+    },
+    "animtree": "/pa/anim/anim_trees/orbital_laser_anim_tree.json"
+  },
+  "tools": [
+    {
+      "spec_id": "/pa/units/orbital/orbital_laser/orbital_laser_tool_weapon.json",
+      "aim_bone": "bone_recoil",
+      "muzzle_bone": "socket_muzzle"
+    }
+  ],
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/orbital"
+    },
+    "fired": {
+      "audio_cue": "/SE/Weapons/orb/orb_ssx_laser_fire",
+      "effect_spec": "/pa/units/orbital/orbital_laser/orbital_laser_muzzle_flash.pfx socket_muzzle",
+      "effect_scale": 3
+    },
+    "died": {
+      "audio_cue": "/SE/Death/orbital",
+      "effect_scale": 2
+    }
+  },
+  "mesh_bounds": [
+    38,
+    38,
+    40
+  ],
+  "TEMP_texelinfo": 31.6199,
+  "fx_offsets": [
+    {
+      "type": "idle",
+      "bone": "bone_rotator",
+      "filename": "/pa/effects/specs/light_2_4_1.pfx",
+      "offset": [
+        8.45,
+        1,
+        -3.5
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_rotator",
+      "filename": "/pa/effects/specs/light_2_4_1.pfx",
+      "offset": [
+        -8.45,
+        -1,
+        -3.5
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_rotator",
+      "filename": "/pa/effects/specs/lightblink_1_4_1.pfx",
+      "offset": [
+        7.6,
+        1,
+        -1.3
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_rotator",
+      "filename": "/pa/effects/specs/lightblink_1_4_1.pfx",
+      "offset": [
+        -7.6,
+        -1,
+        -1.3
+      ]
+    }
+  ]
 }

--- a/pa/units/orbital/orbital_launcher/orbital_launcher.json
+++ b/pa/units/orbital/orbital_launcher/orbital_launcher.json
@@ -1,308 +1,647 @@
 {
-	"base_spec": "/pa/units/land/base_structure/base_structure.json",
-	"display_name": "!LOC(units:orbital_launcher.message):Orbital Launcher",
-	"description": "!LOC(units:basic_manufacturing_builds_and_launches_satellites_and_other_units.message):Basic manufacturing- Builds and launches satellites and other units.",
-	"max_health": 6000,
-	"build_metal_cost": 2700,
-	"atrophy_rate": 45.0,
-	"atrophy_cool_down": 15.0,
-	"buildable_types": "Orbital & FactoryBuild & Basic",
-	"spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
-	"enable_orbital_shell": true,
-	"wait_to_rolloff_time": 3,
-	"factory": {
-		"deploy_projectile": "/pa/units/orbital/orbital_launcher/orbital_launcher_deploy.json",
-		"spawn_points": ["bone_missile01"]
-	},
-	"unit_types": ["UNITTYPE_Orbital",
-	"UNITTYPE_Factory",
-	"UNITTYPE_Construction",
-	"UNITTYPE_Structure",
-	"UNITTYPE_Land",
-	"UNITTYPE_FabBuild",
-	"UNITTYPE_FabAdvBuild",
-	"UNITTYPE_Basic",
-	"UNITTYPE_Important"],
-	"command_caps": ["ORDER_Move",
-	"ORDER_Patrol",
-	"ORDER_FactoryBuild",
-	"ORDER_Attack",
-	"ORDER_Assist"],
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "surface_and_air",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 110
-			},
-			{
-				"layer": "underwater",
-				"channel": "sight",
-				"shape": "capsule",
-				"radius": 110
-			}]
-		}
-	},
-	"model": [{
-		"layer": "WL_LandHorizontal",
-		"filename": "/pa/units/orbital/orbital_launcher/orbital_launcher.papa",
-		"animations": {
-			"build_start": "/pa/units/orbital/orbital_launcher/orbital_launcher_anim_start.papa",
-			"build_loop": "/pa/units/orbital/orbital_launcher/orbital_launcher_anim_build.papa",
-			"build_end": "/pa/units/orbital/orbital_launcher/orbital_launcher_anim_end.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/factory_anim_tree.json",
-		"skirt_decal": "/pa/effects/specs/skirt_orbital_launcher.json"
-	},
-	{
-		"layer": "WL_WaterSurface",
-		"filename": "/pa/units/sea/orbital_launcher/orbital_launcher.papa",
-		"animations": {
-			"build_start": "/pa/units/orbital/orbital_launcher/orbital_launcher_anim_start.papa",
-			"build_loop": "/pa/units/orbital/orbital_launcher/orbital_launcher_anim_build.papa",
-			"build_end": "/pa/units/orbital/orbital_launcher/orbital_launcher_anim_end.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/factory_anim_tree.json"
-	}],
-	"tools": [{
-		"spec_id": "/pa/units/orbital/orbital_launcher/orbital_launcher_build_arm.json",
-		"aim_bone": "bone_root"
-	}],
-	"events": {
-		"died": {
-			"effect_scale": 2.0
-		}
-	},
-	"audio": {
-		"loops": {
-			"build": {
-				"cue": "/SE/Construction/Factory_contruction_loop_orb_launcher",
-				"flag": "build_target_changed",
-				"should_start_func": "has_build_target",
-				"should_stop_func": "no_build_target"
-			}
-		}
-	},
-	"fx_offsets": [{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_muzzle01",
-		"offset": [0.0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	},
-	{
-		"type": "build",
-		"filename": "/pa/effects/specs/fab_spray.pfx",
-		"bone": "socket_muzzle02",
-		"offset": [0.0,
-		0],
-		"orientation": [0,
-		0,
-		0]
-	},{
-			"label" : "Big Antenna",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/effects/specs/light_2_4_2_2.pfx",
-			"offset" : [-5, 9.66, 66.83]
-		},{
-			"label" : "Little Antenna",
-			"type" : "idle",
-			"bone" : "bone_root",
-			"filename" : "/pa/effects/specs/light_2_4_1_2.pfx",
-			"offset" : [-5, 10.85, 64.33]
-		},{
-			"label" : "Ramp 3",
-			"type" : "build",
-			"bone" : "bone_root",
-			"filename" : "/pa/units/orbital/orbital_launcher/light_build.pfx",
-			"offset" : [23.5, -1.15, 4.8]
-		}
-	],
-	"headlights": [{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [-8.0,
-		0.0,
-		5.0],
-		"orientation": [160.0,
-		0.0,
-		0.0],
-		"near_width": 4.5,
-		"near_height": 4.5,
-		"near_distance": 5.0,
-		"far_distance": 40.0,
-		"color": [1.5,
-		1.52,
-		1.6],
-		"intensity": 3.0,
-		"bone": "bone_platform"
-	},
-	{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [8.0,
-		0.0,
-		5.0],
-		"orientation": [-160.0,
-		0.0,
-		0.0],
-		"near_width": 4.5,
-		"near_height": 4.5,
-		"near_distance": 5.0,
-		"far_distance": 40.0,
-		"color": [1.5,
-		1.52,
-		1.6],
-		"intensity": 3.0,
-		"bone": "bone_platform"
-	},
-	{
-		"gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
-		"offset": [-5.0,
-		-21.47,
-		8.99],
-		"orientation": [0.0,
-		35.0,
-		0.0],
-		"near_width": 5.5,
-		"near_height": 5.5,
-		"near_distance": 2.5,
-		"far_distance": 25.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 3.0
-	}],
-	"lamps": [{
-		"offset": [-5.0,
-		23.37,
-		33.65],
-		"radius": 8.0,
-		"color": [0.1,
-		1.0,
-		0.1],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-5.0,
-		18.6,
-		36.19],
-		"radius": 8.0,
-		"color": [0.1,
-		1.0,
-		0.1],
-		"intensity": 2.0
-	},
-	{
-		"offset": [1.57,
-		13.49,
-		9.7],
-		"radius": 4.0,
-		"color": [1.0,
-		0.0,
-		0.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [25.3,
-		16.16,
-		12.23],
-		"radius": 4.0,
-		"color": [1.0,
-		0.0,
-		0.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-5.0,
-		25.04,
-		29.88],
-		"radius": 4.0,
-		"color": [1.0,
-		0.0,
-		0.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-5.0,
-		-21.47,
-		8.99],
-		"radius": 5.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-5.0,
-		7.5,
-		58.92],
-		"radius": 3.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-5.0,
-		12.88,
-		58.92],
-		"radius": 3.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-2.38,
-		10.25,
-		58.92],
-		"radius": 3.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [-7.55,
-		10.25,
-		58.92],
-		"radius": 3.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0
-	},
-	{
-		"offset": [4.14,
-		-10.278,
-		0.0],
-		"radius": 4.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0,
-		"bone": "bone_gantry01"
-	},
-	{
-		"offset": [4.14,
-		-10.278,
-		0.0],
-		"radius": 4.0,
-		"color": [1.0,
-		1.0,
-		1.0],
-		"intensity": 2.0,
-		"bone": "bone_gantry02"
-	}],
-	"TEMP_texelinfo": 63.4807,
-	"mesh_bounds": [50.0454,
-	50.0306,
-	58],
-	"physics": {
-		"collision_layers": "WL_AnyHorizontalGroundOrWaterSurface"
-	}
+  "base_spec": "/pa/units/land/base_structure/base_structure.json",
+  "display_name": "!LOC(units:orbital_launcher.message):Orbital Launcher",
+  "description": "!LOC(units:basic_manufacturing_builds_and_launches_satellites_and_other_units.message):Basic manufacturing- Builds and launches satellites and other units.",
+  "max_health": 6000,
+  "build_metal_cost": 2700,
+  "atrophy_rate": 45.0,
+  "atrophy_cool_down": 15.0,
+  "buildable_types": "Orbital & FactoryBuild & Basic",
+  "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
+  "enable_orbital_shell": true,
+  "wait_to_rolloff_time": 3,
+  "factory": {
+    "deploy_projectile": "/pa/units/orbital/orbital_launcher/orbital_launcher_deploy.json",
+    "spawn_points": [
+      "bone_missile01"
+    ]
+  },
+  "unit_types": [
+    "UNITTYPE_Orbital",
+    "UNITTYPE_Factory",
+    "UNITTYPE_Construction",
+    "UNITTYPE_Structure",
+    "UNITTYPE_Land",
+    "UNITTYPE_FabBuild",
+    "UNITTYPE_FabAdvBuild",
+    "UNITTYPE_Basic",
+    "UNITTYPE_Important"
+  ],
+  "command_caps": [
+    "ORDER_Move",
+    "ORDER_Patrol",
+    "ORDER_FactoryBuild",
+    "ORDER_Attack",
+    "ORDER_Assist"
+  ],
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "surface_and_air",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 110
+        },
+        {
+          "layer": "underwater",
+          "channel": "sight",
+          "shape": "capsule",
+          "radius": 110
+        }
+      ]
+    }
+  },
+  "model": [
+    {
+      "layer": "WL_LandHorizontal",
+      "filename": "/pa/units/orbital/orbital_launcher/orbital_launcher.papa",
+      "animations": {
+        "build_start": "/pa/units/orbital/orbital_launcher/orbital_launcher_anim_start.papa",
+        "build_loop": "/pa/units/orbital/orbital_launcher/orbital_launcher_anim_build.papa",
+        "build_end": "/pa/units/orbital/orbital_launcher/orbital_launcher_anim_end.papa"
+      },
+      "animtree": "/pa/anim/anim_trees/factory_anim_tree.json",
+      "skirt_decal": "/pa/effects/specs/skirt_orbital_launcher.json"
+    },
+    {
+      "layer": "WL_WaterSurface",
+      "filename": "/pa/units/sea/orbital_launcher/orbital_launcher.papa",
+      "animations": {
+        "build_start": "/pa/units/orbital/orbital_launcher/orbital_launcher_anim_start.papa",
+        "build_loop": "/pa/units/orbital/orbital_launcher/orbital_launcher_anim_build.papa",
+        "build_end": "/pa/units/orbital/orbital_launcher/orbital_launcher_anim_end.papa"
+      },
+      "animtree": "/pa/anim/anim_trees/factory_anim_tree.json"
+    }
+  ],
+  "tools": [
+    {
+      "spec_id": "/pa/units/orbital/orbital_launcher/orbital_launcher_build_arm.json",
+      "aim_bone": "bone_root"
+    }
+  ],
+  "events": {
+    "died": {
+      "effect_scale": 2.0
+    }
+  },
+  "audio": {
+    "loops": {
+      "build": {
+        "cue": "/SE/Construction/Factory_contruction_loop_orb_launcher",
+        "flag": "build_target_changed",
+        "should_start_func": "has_build_target",
+        "should_stop_func": "no_build_target"
+      }
+    }
+  },
+  "fx_offsets": [
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_muzzle01",
+      "offset": [
+        0.0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "type": "build",
+      "filename": "/pa/effects/specs/fab_spray.pfx",
+      "bone": "socket_muzzle02",
+      "offset": [
+        0.0,
+        0
+      ],
+      "orientation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "label": "Big Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -5,
+        9.66,
+        66.83
+      ]
+    },
+    {
+      "label": "Little Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -5,
+        10.85,
+        64.33
+      ]
+    },
+    {
+      "label": "Ramp 3",
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_launcher/light_build.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "label": "Ramp 3",
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_launcher/light_build.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "label": "Little Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -5,
+        10.85,
+        64.33
+      ]
+    },
+    {
+      "label": "Big Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -5,
+        9.66,
+        66.83
+      ]
+    },
+    {
+      "label": "Big Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -5,
+        9.66,
+        66.83
+      ]
+    },
+    {
+      "label": "Little Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -5,
+        10.85,
+        64.33
+      ]
+    },
+    {
+      "label": "Ramp 3",
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_launcher/light_build.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "label": "Ramp 3",
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_launcher/light_build.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "label": "Little Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -5,
+        10.85,
+        64.33
+      ]
+    },
+    {
+      "label": "Big Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -5,
+        9.66,
+        66.83
+      ]
+    },
+    {
+      "label": "Big Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -5,
+        9.66,
+        66.83
+      ]
+    },
+    {
+      "label": "Little Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -5,
+        10.85,
+        64.33
+      ]
+    },
+    {
+      "label": "Ramp 3",
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_launcher/light_build.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "label": "Ramp 3",
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_launcher/light_build.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "label": "Little Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -5,
+        10.85,
+        64.33
+      ]
+    },
+    {
+      "label": "Big Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -5,
+        9.66,
+        66.83
+      ]
+    },
+    {
+      "label": "Big Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -5,
+        9.66,
+        66.83
+      ]
+    },
+    {
+      "label": "Little Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -5,
+        10.85,
+        64.33
+      ]
+    },
+    {
+      "label": "Ramp 3",
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_launcher/light_build.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "label": "Ramp 3",
+      "type": "build",
+      "bone": "bone_root",
+      "filename": "/pa/units/orbital/orbital_launcher/light_build.pfx",
+      "offset": [
+        23.5,
+        -1.15,
+        4.8
+      ]
+    },
+    {
+      "label": "Little Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -5,
+        10.85,
+        64.33
+      ]
+    },
+    {
+      "label": "Big Antenna",
+      "type": "idle",
+      "bone": "bone_root",
+      "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+      "offset": [
+        -5,
+        9.66,
+        66.83
+      ]
+    }
+  ],
+  "headlights": [
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        -8.0,
+        0.0,
+        5.0
+      ],
+      "orientation": [
+        160.0,
+        0.0,
+        0.0
+      ],
+      "near_width": 4.5,
+      "near_height": 4.5,
+      "near_distance": 5.0,
+      "far_distance": 40.0,
+      "color": [
+        1.5,
+        1.52,
+        1.6
+      ],
+      "intensity": 3.0,
+      "bone": "bone_platform"
+    },
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        8.0,
+        0.0,
+        5.0
+      ],
+      "orientation": [
+        -160.0,
+        0.0,
+        0.0
+      ],
+      "near_width": 4.5,
+      "near_height": 4.5,
+      "near_distance": 5.0,
+      "far_distance": 40.0,
+      "color": [
+        1.5,
+        1.52,
+        1.6
+      ],
+      "intensity": 3.0,
+      "bone": "bone_platform"
+    },
+    {
+      "gobo": "/pa/effects/textures/gobo/spotlight_gobo.papa",
+      "offset": [
+        -5.0,
+        -21.47,
+        8.99
+      ],
+      "orientation": [
+        0.0,
+        35.0,
+        0.0
+      ],
+      "near_width": 5.5,
+      "near_height": 5.5,
+      "near_distance": 2.5,
+      "far_distance": 25.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 3.0
+    }
+  ],
+  "lamps": [
+    {
+      "offset": [
+        -5.0,
+        23.37,
+        33.65
+      ],
+      "radius": 8.0,
+      "color": [
+        0.1,
+        1.0,
+        0.1
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -5.0,
+        18.6,
+        36.19
+      ],
+      "radius": 8.0,
+      "color": [
+        0.1,
+        1.0,
+        0.1
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        1.57,
+        13.49,
+        9.7
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        25.3,
+        16.16,
+        12.23
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -5.0,
+        25.04,
+        29.88
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -5.0,
+        -21.47,
+        8.99
+      ],
+      "radius": 5.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -5.0,
+        7.5,
+        58.92
+      ],
+      "radius": 3.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -5.0,
+        12.88,
+        58.92
+      ],
+      "radius": 3.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -2.38,
+        10.25,
+        58.92
+      ],
+      "radius": 3.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        -7.55,
+        10.25,
+        58.92
+      ],
+      "radius": 3.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0
+    },
+    {
+      "offset": [
+        4.14,
+        -10.278,
+        0.0
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0,
+      "bone": "bone_gantry01"
+    },
+    {
+      "offset": [
+        4.14,
+        -10.278,
+        0.0
+      ],
+      "radius": 4.0,
+      "color": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "intensity": 2.0,
+      "bone": "bone_gantry02"
+    }
+  ],
+  "TEMP_texelinfo": 63.4807,
+  "mesh_bounds": [
+    50.0454,
+    50.0306,
+    58
+  ],
+  "physics": {
+    "collision_layers": "WL_AnyHorizontalGroundOrWaterSurface"
+  }
 }

--- a/pa/units/orbital/solar_array/solar_array.json
+++ b/pa/units/orbital/solar_array/solar_array.json
@@ -1,91 +1,117 @@
 {
-	"base_spec": "/pa/units/orbital/base_orbital/base_orbital.json",
-	"display_name": "!LOC(units:solar_array.message):Solar Array",
-	"description": "!LOC(units:manufacturing_orbital_energy_generation.message):Manufacturing- Orbital energy generation.",
-	"max_health": 2500,
-	"build_metal_cost": 2800,
-	"spawn_layers": "WL_Orbital",
-	"attachable": {
-		"offsets": {
-			"root": [0,
-			0,
-			0]
-		}
-	},
-	"production": {
-		"energy": 4000
-	},
-	"unit_types": ["UNITTYPE_Mobile",
-	"UNITTYPE_Orbital",
-	"UNITTYPE_EnergyProduction",
-	"UNITTYPE_Economy",
-	"UNITTYPE_Advanced",
-	"UNITTYPE_FactoryBuild"],
-	"command_caps": ["ORDER_Move",
-	"ORDER_Patrol",
-	"ORDER_Assist"],
-	"navigation": {
-		"type": "orbital",
-		"acceleration": 10,
-		"brake": 10,
-		"move_speed": 10,
-		"turn_speed": 45,
-		"hover_time": -1.0
-	},
-	"physics": {
-		"radius": 8,
-		"push_class": 25,
-		"gravity_scalar": 0.001
-	},
-	"recon": {
-		"observer": {
-			"items": [{
-				"layer": "orbital",
-				"channel": "sight",
-				"shape": "sphere",
-				"radius": 100
-			}]
-		}
-	},
-	"model": {
-		"filename": "/pa/units/orbital/solar_array/solar_array.papa",
-		"animations": {
-			"open": "/pa/units/orbital/solar_array/solar_array_anim_open.papa",
-			"closed": "/pa/units/orbital/solar_array/solar_array_anim_closed.papa",
-			"deploy": "/pa/units/orbital/solar_array/solar_array_anim_deploy.papa"
-		},
-		"animtree": "/pa/anim/anim_trees/satellite_launched_anim_tree.json"
-	},
-	"events": {
-		"build_complete": {
-			"audio_cue": "/SE/Build_Complete/orbital"
-		},
-		"fired": {
-			"audio_cue": "/SE/Weapons/air/bomber_fire"
-		},
-		"died": {
-			"audio_cue": "/SE/Death/orbital",
-			"effect_scale": 1.5
-		}
-	},
-	"fx_offsets" : [{
-			"type" : "idle",
-			"bone" : "bone_body",
-			"filename" : "/pa/effects/specs/light_2_4_1.pfx",
-			"offset" : [0, -12.5, 0]
-		},{
-			"type" : "idle",
-			"bone" : "bone_body",
-			"filename" : "/pa/effects/specs/light_2_4_1_4.pfx",
-			"offset" : [0.5, -10, 0]
-		},{
-			"type" : "idle",
-			"bone" : "bone_body",
-			"filename" : "/pa/effects/specs/light_2_4_1_2.pfx",
-			"offset" : [-0.5, -11.2, 0]
-		}],
-	"mesh_bounds": [50,
-	15,
-	6],
-	"TEMP_texelinfo": 25.0
+  "base_spec": "/pa/units/orbital/base_orbital/base_orbital.json",
+  "display_name": "!LOC(units:solar_array.message):Solar Array",
+  "description": "!LOC(units:manufacturing_orbital_energy_generation.message):Manufacturing- Orbital energy generation.",
+  "max_health": 2500,
+  "build_metal_cost": 2800,
+  "spawn_layers": "WL_Orbital",
+  "attachable": {
+    "offsets": {
+      "root": [
+        0,
+        0,
+        0
+      ]
+    }
+  },
+  "production": {
+    "energy": 4000
+  },
+  "unit_types": [
+    "UNITTYPE_Mobile",
+    "UNITTYPE_Orbital",
+    "UNITTYPE_EnergyProduction",
+    "UNITTYPE_Economy",
+    "UNITTYPE_Advanced",
+    "UNITTYPE_FactoryBuild"
+  ],
+  "command_caps": [
+    "ORDER_Move",
+    "ORDER_Patrol",
+    "ORDER_Assist"
+  ],
+  "navigation": {
+    "type": "orbital",
+    "acceleration": 10,
+    "brake": 10,
+    "move_speed": 10,
+    "turn_speed": 45,
+    "hover_time": -1.0
+  },
+  "physics": {
+    "radius": 8,
+    "push_class": 25,
+    "gravity_scalar": 0.001
+  },
+  "recon": {
+    "observer": {
+      "items": [
+        {
+          "layer": "orbital",
+          "channel": "sight",
+          "shape": "sphere",
+          "radius": 100
+        }
+      ]
+    }
+  },
+  "model": {
+    "filename": "/pa/units/orbital/solar_array/solar_array.papa",
+    "animations": {
+      "open": "/pa/units/orbital/solar_array/solar_array_anim_open.papa",
+      "closed": "/pa/units/orbital/solar_array/solar_array_anim_closed.papa",
+      "deploy": "/pa/units/orbital/solar_array/solar_array_anim_deploy.papa"
+    },
+    "animtree": "/pa/anim/anim_trees/satellite_launched_anim_tree.json"
+  },
+  "events": {
+    "build_complete": {
+      "audio_cue": "/SE/Build_Complete/orbital"
+    },
+    "fired": {
+      "audio_cue": "/SE/Weapons/air/bomber_fire"
+    },
+    "died": {
+      "audio_cue": "/SE/Death/orbital",
+      "effect_scale": 1.5
+    }
+  },
+  "mesh_bounds": [
+    50,
+    15,
+    6
+  ],
+  "TEMP_texelinfo": 25.0,
+  "fx_offsets": [
+    {
+      "type": "idle",
+      "bone": "bone_body",
+      "filename": "/pa/effects/specs/light_2_4_1.pfx",
+      "offset": [
+        0,
+        -12.5,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_body",
+      "filename": "/pa/effects/specs/light_2_4_1_4.pfx",
+      "offset": [
+        0.5,
+        -10,
+        0
+      ]
+    },
+    {
+      "type": "idle",
+      "bone": "bone_body",
+      "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+      "offset": [
+        -0.5,
+        -11.2,
+        0
+      ]
+    }
+  ]
 }

--- a/pa_fx_gen.json
+++ b/pa_fx_gen.json
@@ -1,0 +1,5616 @@
+{
+  "options": {
+    "output_dir": ".",
+    "pretty_print_effects": true,
+    "indent": 2
+  },
+  "modinfo": {
+    "context": "client",
+    "identifier": "com.uberent.pa.PAFX",
+    "display_name": "PA-FX",
+    "description": "Adding more effects to Buildings & Units",
+    "author": "Alpha2546, Fr33Lancer",
+    "version": "2.5",
+    "signature": "not yet implemented",
+    "forum": "https://forums.uberent.com/threads/rel-pa-fx-moar-effects-in-pa-75499.66155/",
+    "icon": "https://i.imgflip.com/ekl6p.gif",
+    "category": [
+      "in-game",
+      "shader",
+      "colours",
+      "particles",
+      "effects",
+      "buildings"
+    ],
+    "priority": 100
+  },
+  "mod": [
+    {
+      "target": "pa/units/air/air_factory/air_factory.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_root",
+            "filename": "/pa/units/air/air_factory/light_build.pfx",
+            "offset": [
+              0,
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/units/air/air_factory/light_build_bone_2.pfx",
+            "offset": [
+              0,
+              9.4,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/units/air/air_factory/light_build_bone_2_2.pfx",
+            "offset": [
+              0,
+              -9.4,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
+            "offset": [
+              7.25,
+              -7.25,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
+            "offset": [
+              -7.25,
+              -7.25,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/units/air/air_factory/light_build_bone_4.pfx",
+            "offset": [
+              7.25,
+              7.25,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/units/air/air_factory/light_build_bone_4.pfx",
+            "offset": [
+              -7.25,
+              7.25,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/air/air_factory/dot_1.pfx",
+            "offset": [
+              0,
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              9.4,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              -9.4,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              7.25,
+              -7.25,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -7.25,
+              -7.25,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              7.25,
+              7.25,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -7.25,
+              7.25,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -7.25,
+              7.25,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              7.25,
+              7.25,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -7.25,
+              -7.25,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              7.25,
+              -7.25,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              -9.4,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              9.4,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/air/air_factory/dot_1.pfx",
+            "offset": [
+              0,
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/units/air/air_factory/light_build_bone_4.pfx",
+            "offset": [
+              -7.25,
+              7.25,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/units/air/air_factory/light_build_bone_4.pfx",
+            "offset": [
+              7.25,
+              7.25,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
+            "offset": [
+              -7.25,
+              -7.25,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/units/air/air_factory/light_build_bone_4_1.pfx",
+            "offset": [
+              7.25,
+              -7.25,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/units/air/air_factory/light_build_bone_2_2.pfx",
+            "offset": [
+              0,
+              -9.4,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_outsideRing",
+            "filename": "/pa/units/air/air_factory/light_build_bone_2.pfx",
+            "offset": [
+              0,
+              9.4,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_root",
+            "filename": "/pa/units/air/air_factory/light_build.pfx",
+            "offset": [
+              0,
+              0,
+              0
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "target": "pa/units/air/air_factory_adv/air_factory_adv.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/air/air_factory_adv/dot_1.pfx",
+            "offset": [
+              0,
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_root",
+            "filename": "/pa/units/air/air_factory_adv/light_build.pfx",
+            "offset": [
+              0,
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle01",
+            "filename": "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle02",
+            "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle03",
+            "filename": "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle04",
+            "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle05",
+            "filename": "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle06",
+            "filename": "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle07",
+            "filename": "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle08",
+            "filename": "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle08",
+            "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+            "offset": [
+              -12.3,
+              -5,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle05",
+            "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+            "offset": [
+              12.3,
+              -5,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle01",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle02",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle03",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle04",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle05",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle06",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle07",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle08",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle08",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -12.3,
+              -5,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle05",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              12.3,
+              -5,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle05",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              12.3,
+              -5,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle08",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -12.3,
+              -5,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle08",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle07",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle06",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle05",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle04",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle03",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle02",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle01",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle05",
+            "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+            "offset": [
+              12.3,
+              -5,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle08",
+            "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+            "offset": [
+              -12.3,
+              -5,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle08",
+            "filename": "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle07",
+            "filename": "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle06",
+            "filename": "/pa/units/air/air_factory_adv/light_build_bone_4.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle05",
+            "filename": "/pa/units/air/air_factory_adv/light_build_bone_3.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle04",
+            "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle03",
+            "filename": "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle02",
+            "filename": "/pa/units/air/air_factory_adv/light_build_bone_2.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle01",
+            "filename": "/pa/units/air/air_factory_adv/light_build_bone_1.pfx",
+            "offset": [
+              0,
+              1.45,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_root",
+            "filename": "/pa/units/air/air_factory_adv/light_build.pfx",
+            "offset": [
+              0,
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/air/air_factory_adv/dot_1.pfx",
+            "offset": [
+              0,
+              0,
+              0
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "target": "pa/units/land/air_defense/air_defense.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets",
+          "value": [
+            {
+              "type": "idle",
+              "bone": "socket_leftMuzzle",
+              "filename": "/pa/units/land/air_defense/aa_lights.pfx",
+              "offset": [
+                0,
+                0.75,
+                2.1
+              ]
+            },
+            {
+              "type": "idle",
+              "bone": "socket_rightMuzzle",
+              "filename": "/pa/units/land/air_defense/aa_lights.pfx",
+              "offset": [
+                0,
+                0.75,
+                2.1
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "pa/units/land/air_defense_adv/air_defense_adv.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets",
+          "value": [
+            {
+              "type": "idle",
+              "bone": "socket_leftMuzzle01",
+              "filename": "/pa/units/land/air_defense_adv/aa_lights.pfx",
+              "offset": [
+                0,
+                4.5,
+                1.55
+              ]
+            },
+            {
+              "type": "idle",
+              "bone": "socket_rightMuzzle01",
+              "filename": "/pa/units/land/air_defense_adv/aa_lights.pfx",
+              "offset": [
+                0,
+                4.5,
+                1.55
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "pa/units/land/anti_nuke_launcher/anti_nuke_launcher.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_radarPitch",
+            "filename": "/pa/effects/specs/light_2_2_2.pfx",
+            "offset": [
+              3.5,
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_radarPitch",
+            "filename": "/pa/effects/specs/light_2_2_2.pfx",
+            "offset": [
+              3.5,
+              0,
+              0
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "target": "pa/units/land/bot_factory/bot_factory.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/bot_factory/light_build.pfx",
+            "offset": [
+              23.5,
+              -1.15,
+              4.8
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/bot_factory/dot_1.pfx",
+            "offset": [
+              23.5,
+              -1.15,
+              4.8
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_armShoulder01",
+            "filename": "/pa/units/land/bot_factory/light_build_bone.pfx",
+            "offset": [
+              2.5,
+              1.3,
+              -1.4
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_armShoulder02",
+            "filename": "/pa/units/land/bot_factory/light_build_bone.pfx",
+            "offset": [
+              2.5,
+              1.3,
+              1.4
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_armShoulder01",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              2.5,
+              1.3,
+              -1.4
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_armShoulder02",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              2.5,
+              1.3,
+              1.4
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMP FIRST RIGHT",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+            "offset": [
+              3.7,
+              8.2,
+              3.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMP SECOND RIGHT",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+            "offset": [
+              3.7,
+              10.8,
+              2.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMP THIRD RIGHT",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+            "offset": [
+              3.7,
+              13.2,
+              1.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMP FIRST LEFT",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+            "offset": [
+              3.7,
+              -9.8,
+              3.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMP SECOND LEFT",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+            "offset": [
+              3.7,
+              -12.2,
+              2.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMP THIRD LEFT",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+            "offset": [
+              3.7,
+              -14.8,
+              1.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMP THIRD LEFT",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+            "offset": [
+              3.7,
+              -14.8,
+              1.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMP SECOND LEFT",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+            "offset": [
+              3.7,
+              -12.2,
+              2.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMP FIRST LEFT",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+            "offset": [
+              3.7,
+              -9.8,
+              3.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMP THIRD RIGHT",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+            "offset": [
+              3.7,
+              13.2,
+              1.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMP SECOND RIGHT",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+            "offset": [
+              3.7,
+              10.8,
+              2.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMP FIRST RIGHT",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/bot_factory/ramp_light_3_1.pfx",
+            "offset": [
+              3.7,
+              8.2,
+              3.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_armShoulder02",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              2.5,
+              1.3,
+              1.4
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_armShoulder01",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              2.5,
+              1.3,
+              -1.4
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_armShoulder02",
+            "filename": "/pa/units/land/bot_factory/light_build_bone.pfx",
+            "offset": [
+              2.5,
+              1.3,
+              1.4
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_armShoulder01",
+            "filename": "/pa/units/land/bot_factory/light_build_bone.pfx",
+            "offset": [
+              2.5,
+              1.3,
+              -1.4
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/bot_factory/dot_1.pfx",
+            "offset": [
+              23.5,
+              -1.15,
+              4.8
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/bot_factory/light_build.pfx",
+            "offset": [
+              23.5,
+              -1.15,
+              4.8
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "target": "pa/units/land/bot_factory_adv/bot_factory_adv.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/bot_factory_adv/light_build.pfx",
+            "offset": [
+              15,
+              0,
+              10.7
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/bot_factory_adv/dot_1.pfx",
+            "offset": [
+              15,
+              0,
+              10.7
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_armElbow03",
+            "filename": "/pa/units/land/bot_factory_adv/light_build_bone_1.pfx",
+            "offset": [
+              3.0,
+              0.3,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_armElbow02",
+            "filename": "/pa/units/land/bot_factory_adv/light_build_bone_2.pfx",
+            "offset": [
+              3.0,
+              0.3,
+              1.2
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_armElbow01",
+            "filename": "/pa/units/land/bot_factory_adv/light_build_bone_3.pfx",
+            "offset": [
+              3.0,
+              0.3,
+              -1.2
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_armElbow03",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              3.0,
+              0.3,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_armElbow02",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              3.0,
+              0.3,
+              1.2
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_armElbow01",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              3.0,
+              0.3,
+              -1.2
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_armElbow01",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              3.0,
+              0.3,
+              -1.2
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_armElbow02",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              3.0,
+              0.3,
+              1.2
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_armElbow03",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              3.0,
+              0.3,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_armElbow01",
+            "filename": "/pa/units/land/bot_factory_adv/light_build_bone_3.pfx",
+            "offset": [
+              3.0,
+              0.3,
+              -1.2
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_armElbow02",
+            "filename": "/pa/units/land/bot_factory_adv/light_build_bone_2.pfx",
+            "offset": [
+              3.0,
+              0.3,
+              1.2
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_armElbow03",
+            "filename": "/pa/units/land/bot_factory_adv/light_build_bone_1.pfx",
+            "offset": [
+              3.0,
+              0.3,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/bot_factory_adv/dot_1.pfx",
+            "offset": [
+              15,
+              0,
+              10.7
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/bot_factory_adv/light_build.pfx",
+            "offset": [
+              15,
+              0,
+              10.7
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "target": "pa/units/land/control_module/control_module.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "filename": "/pa/units/land/control_module/PulseStrip1.pfx",
+            "bone": "bone_rightShieldSet",
+            "offset": [
+              22,
+              -19.8,
+              4
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "filename": "/pa/units/land/control_module/PulseStrip2.pfx",
+            "bone": "bone_rightShieldSet",
+            "offset": [
+              22,
+              0.2,
+              4
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "filename": "/pa/units/land/control_module/PulseStrip3.pfx",
+            "bone": "bone_rightShieldSet",
+            "offset": [
+              22,
+              20.2,
+              4
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "filename": "/pa/units/land/control_module/PulseStrip1.pfx",
+            "bone": "bone_leftShieldSet",
+            "offset": [
+              22,
+              19.8,
+              4
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "filename": "/pa/units/land/control_module/PulseStrip2.pfx",
+            "bone": "bone_leftShieldSet",
+            "offset": [
+              22,
+              -0.2,
+              4
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "filename": "/pa/units/land/control_module/PulseStrip3.pfx",
+            "bone": "bone_leftShieldSet",
+            "offset": [
+              22,
+              -20.2,
+              4
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "filename": "/pa/units/land/control_module/PulseStrip3.pfx",
+            "bone": "bone_leftShieldSet",
+            "offset": [
+              22,
+              -20.2,
+              4
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "filename": "/pa/units/land/control_module/PulseStrip2.pfx",
+            "bone": "bone_leftShieldSet",
+            "offset": [
+              22,
+              -0.2,
+              4
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "filename": "/pa/units/land/control_module/PulseStrip1.pfx",
+            "bone": "bone_leftShieldSet",
+            "offset": [
+              22,
+              19.8,
+              4
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "filename": "/pa/units/land/control_module/PulseStrip3.pfx",
+            "bone": "bone_rightShieldSet",
+            "offset": [
+              22,
+              20.2,
+              4
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "filename": "/pa/units/land/control_module/PulseStrip2.pfx",
+            "bone": "bone_rightShieldSet",
+            "offset": [
+              22,
+              0.2,
+              4
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "filename": "/pa/units/land/control_module/PulseStrip1.pfx",
+            "bone": "bone_rightShieldSet",
+            "offset": [
+              22,
+              -19.8,
+              4
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "target": "pa/units/land/energy_plant_adv/energy_plant_adv.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/stable_light_2.pfx",
+            "offset": [
+              0,
+              -7.66,
+              21.75
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/stable_light_2.pfx",
+            "offset": [
+              -7.66,
+              0,
+              21.75
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/stable_light_2.pfx",
+            "offset": [
+              7.66,
+              0,
+              21.75
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/stable_light_2.pfx",
+            "offset": [
+              7.66,
+              0,
+              21.75
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/stable_light_2.pfx",
+            "offset": [
+              -7.66,
+              0,
+              21.75
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/stable_light_2.pfx",
+            "offset": [
+              0,
+              -7.66,
+              21.75
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "target": "pa/units/land/energy_storage/energy_storage.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets",
+          "value": [
+            {
+              "type": "idle",
+              "filename": "/pa/units/land/energy_storage/energy_storage.pfx",
+              "offset": [
+                0,
+                0,
+                5
+              ]
+            },
+            {
+              "type": "idle",
+              "bone": "bone_antenna01",
+              "filename": "/pa/effects/specs/stable_light_2.pfx",
+              "offset": [
+                5.15,
+                5.15,
+                13
+              ]
+            },
+            {
+              "type": "idle",
+              "bone": "bone_antenna01",
+              "filename": "/pa/effects/specs/stable_light_2.pfx",
+              "offset": [
+                -5.15,
+                -5.15,
+                13
+              ]
+            },
+            {
+              "type": "idle",
+              "bone": "bone_antenna01",
+              "filename": "/pa/effects/specs/stable_light_2.pfx",
+              "offset": [
+                -5.15,
+                5.15,
+                13
+              ]
+            },
+            {
+              "type": "idle",
+              "bone": "bone_antenna01",
+              "filename": "/pa/effects/specs/stable_light_2.pfx",
+              "offset": [
+                5.15,
+                -5.15,
+                13
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "pa/units/land/laser_defense/laser_defense.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets",
+          "value": [
+            {
+              "type": "idle",
+              "bone": "bone_pitch",
+              "filename": "/pa/units/land/laser_defense/turret_lights.pfx",
+              "offset": [
+                2.05,
+                -4.9,
+                0.2
+              ]
+            },
+            {
+              "type": "idle",
+              "bone": "bone_pitch",
+              "filename": "/pa/units/land/laser_defense/turret_lights.pfx",
+              "offset": [
+                -2.05,
+                -4.9,
+                0.2
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "pa/units/land/laser_defense_adv/laser_defense_adv.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets",
+          "value": [
+            {
+              "type": "idle",
+              "bone": "bone_pitch",
+              "filename": "/pa/units/land/laser_defense_adv/turret_light_middle.pfx",
+              "offset": [
+                0,
+                -5.4,
+                3.4
+              ]
+            },
+            {
+              "type": "idle",
+              "bone": "bone_pitch",
+              "filename": "/pa/units/land/laser_defense_adv/turret_lights.pfx",
+              "offset": [
+                -2.05,
+                -4.15,
+                1.8
+              ]
+            },
+            {
+              "type": "idle",
+              "bone": "bone_pitch",
+              "filename": "/pa/units/land/laser_defense_adv/turret_lights.pfx",
+              "offset": [
+                2.05,
+                -4.15,
+                1.8
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "pa/units/land/laser_defense_single/laser_defense_single.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets",
+          "value": [
+            {
+              "type": "idle",
+              "bone": "bone_pitch",
+              "filename": "/pa/units/land/laser_defense_single/turret_lights.pfx",
+              "offset": [
+                -1.1,
+                -3.625,
+                0.85
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "pa/units/land/metal_extractor/metal_extractor.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets",
+          "value": [
+            {
+              "type": "idle",
+              "filename": "/pa/units/land/metal_extractor/metal_extractor_idle.pfx",
+              "offset": [
+                0,
+                0,
+                5
+              ]
+            },
+            {
+              "type": "idle",
+              "bone": "bone_root",
+              "filename": "/pa/units/land/metal_extractor/lightblink_2_2_2.pfx",
+              "offset": [
+                0,
+                0,
+                9.7
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "pa/units/land/metal_extractor_adv/metal_extractor_adv.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets",
+          "value": [
+            {
+              "type": "idle",
+              "filename": "/pa/units/land/metal_extractor_adv/metal_extractor_adv.pfx",
+              "offset": [
+                0,
+                0,
+                5
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "pa/units/land/metal_storage/metal_storage.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets",
+          "value": [
+            {
+              "type": "idle",
+              "filename": "/pa/units/land/metal_storage/metal_storage.pfx",
+              "offset": [
+                0,
+                0,
+                5
+              ]
+            },
+            {
+              "type": "idle",
+              "bone": "bone_root",
+              "filename": "/pa/effects/specs/stable_light_2.pfx",
+              "offset": [
+                -2.5,
+                8.157,
+                12.7
+              ]
+            },
+            {
+              "type": "idle",
+              "bone": "bone_root",
+              "filename": "/pa/effects/specs/stable_light_2.pfx",
+              "offset": [
+                2.5,
+                8.157,
+                12.7
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "pa/units/land/nuke_launcher/nuke_launcher.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Big Antenna",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+            "offset": [
+              0,
+              5.2,
+              23.5
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Little Antenna",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+            "offset": [
+              0,
+              4.3,
+              21.85
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Little Antenna",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+            "offset": [
+              0,
+              4.3,
+              21.85
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Big Antenna",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+            "offset": [
+              0,
+              5.2,
+              23.5
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "target": "pa/units/land/tactical_missile_launcher/tactical_missile_launcher.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets",
+          "value": [
+            {
+              "type": "idle",
+              "filename": "/pa/units/land/tactical_missile_launcher/light_2_3_3.pfx",
+              "offset": [
+                3.9,
+                0.6,
+                8.8
+              ]
+            },
+            {
+              "type": "idle",
+              "bone": "bone_root",
+              "filename": "/pa/units/land/tactical_missile_launcher/light_2_3_1.pfx",
+              "offset": [
+                -3.9,
+                -0.6,
+                8.8
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "pa/units/land/teleporter/teleporter.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Big Antenna Right",
+            "type": "idle",
+            "filename": "/pa/effects/specs/stable_light_2.pfx",
+            "bone": "bone_root",
+            "offset": [
+              17.1,
+              -11,
+              11.8
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Little Antenna Right",
+            "type": "idle",
+            "filename": "/pa/effects/specs/stable_light_2.pfx",
+            "bone": "bone_root",
+            "offset": [
+              18.9,
+              -11,
+              9.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Big Antenna Left",
+            "type": "idle",
+            "filename": "/pa/effects/specs/stable_light_2.pfx",
+            "bone": "bone_root",
+            "offset": [
+              -17.1,
+              -11,
+              11.8
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMPLEFT",
+            "type": "idle",
+            "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+            "bone": "bone_root",
+            "offset": [
+              -6.75,
+              4.8,
+              1.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMPMIDDLE",
+            "type": "idle",
+            "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+            "bone": "bone_root",
+            "offset": [
+              0,
+              4.8,
+              1.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMPRIGHT",
+            "type": "idle",
+            "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+            "bone": "bone_root",
+            "offset": [
+              6.75,
+              4.8,
+              1.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMPBIGRIGHT",
+            "type": "idle",
+            "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+            "bone": "bone_root",
+            "offset": [
+              6.75,
+              15.2,
+              1.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMPBIGMIDDLE",
+            "type": "idle",
+            "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+            "bone": "bone_root",
+            "offset": [
+              0,
+              15.2,
+              1.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMPBIGLEFT",
+            "type": "idle",
+            "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+            "bone": "bone_root",
+            "offset": [
+              -6.75,
+              15.2,
+              1.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Little Antenna Left",
+            "type": "idle",
+            "filename": "/pa/effects/specs/stable_light_2.pfx",
+            "bone": "bone_root",
+            "offset": [
+              -18.9,
+              -11,
+              9.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Little Antenna Left",
+            "type": "idle",
+            "filename": "/pa/effects/specs/stable_light_2.pfx",
+            "bone": "bone_root",
+            "offset": [
+              -18.9,
+              -11,
+              9.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMPBIGLEFT",
+            "type": "idle",
+            "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+            "bone": "bone_root",
+            "offset": [
+              -6.75,
+              15.2,
+              1.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMPBIGMIDDLE",
+            "type": "idle",
+            "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+            "bone": "bone_root",
+            "offset": [
+              0,
+              15.2,
+              1.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMPBIGRIGHT",
+            "type": "idle",
+            "filename": "/pa/units/land/teleporter/ramp_light_big_1.pfx",
+            "bone": "bone_root",
+            "offset": [
+              6.75,
+              15.2,
+              1.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMPRIGHT",
+            "type": "idle",
+            "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+            "bone": "bone_root",
+            "offset": [
+              6.75,
+              4.8,
+              1.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMPMIDDLE",
+            "type": "idle",
+            "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+            "bone": "bone_root",
+            "offset": [
+              0,
+              4.8,
+              1.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "RAMPLEFT",
+            "type": "idle",
+            "filename": "/pa/units/land/teleporter/ramp_light_1.pfx",
+            "bone": "bone_root",
+            "offset": [
+              -6.75,
+              4.8,
+              1.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Big Antenna Left",
+            "type": "idle",
+            "filename": "/pa/effects/specs/stable_light_2.pfx",
+            "bone": "bone_root",
+            "offset": [
+              -17.1,
+              -11,
+              11.8
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Little Antenna Right",
+            "type": "idle",
+            "filename": "/pa/effects/specs/stable_light_2.pfx",
+            "bone": "bone_root",
+            "offset": [
+              18.9,
+              -11,
+              9.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Big Antenna Right",
+            "type": "idle",
+            "filename": "/pa/effects/specs/stable_light_2.pfx",
+            "bone": "bone_root",
+            "offset": [
+              17.1,
+              -11,
+              11.8
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "target": "pa/units/land/vehicle_factory/vehicle_factory.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_bar002",
+            "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+            "offset": [
+              6.1,
+              2.1,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_bar002",
+            "filename": "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
+            "offset": [
+              0,
+              0.3,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_bar002",
+            "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+            "offset": [
+              -6.1,
+              2.1,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_bar001",
+            "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+            "offset": [
+              6.1,
+              2.1,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_bar001",
+            "filename": "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
+            "offset": [
+              0,
+              0.3,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_bar001",
+            "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+            "offset": [
+              -6.1,
+              2.1,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_bar002",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              6.1,
+              2.1,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_bar002",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              0.3,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_bar002",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -6.1,
+              2.1,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_bar001",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              6.1,
+              2.1,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_bar001",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              0.3,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_bar001",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -6.1,
+              2.1,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_bar001",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -6.1,
+              2.1,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_bar001",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              0.3,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_bar001",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              6.1,
+              2.1,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_bar002",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -6.1,
+              2.1,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_bar002",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              0,
+              0.3,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_bar002",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              6.1,
+              2.1,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_bar001",
+            "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+            "offset": [
+              -6.1,
+              2.1,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_bar001",
+            "filename": "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
+            "offset": [
+              0,
+              0.3,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_bar001",
+            "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+            "offset": [
+              6.1,
+              2.1,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_bar002",
+            "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+            "offset": [
+              -6.1,
+              2.1,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_bar002",
+            "filename": "/pa/units/land/vehicle_factory/light_build_bone_2.pfx",
+            "offset": [
+              0,
+              0.3,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_bar002",
+            "filename": "/pa/units/land/vehicle_factory/light_build_bone_1.pfx",
+            "offset": [
+              6.1,
+              2.1,
+              0.6
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "target": "pa/units/land/vehicle_factory_adv/vehicle_factory_adv.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle01",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
+            "offset": [
+              4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle01",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
+            "offset": [
+              -4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle03",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
+            "offset": [
+              4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle03",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
+            "offset": [
+              -4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle05",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
+            "offset": [
+              4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle05",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
+            "offset": [
+              -4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle07",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
+            "offset": [
+              4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle07",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
+            "offset": [
+              -4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle01",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle01",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle03",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle03",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle05",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle05",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle07",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle07",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              21,
+              -3.5,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "Bone_root",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              21,
+              3.5,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -21,
+              -3.5,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "Bone_root",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -21,
+              3.5,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
+            "offset": [
+              21,
+              -3.5,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "Bone_root",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
+            "offset": [
+              21,
+              3.5,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
+            "offset": [
+              -21,
+              -3.5,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "Bone_root",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
+            "offset": [
+              -21,
+              3.5,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "Bone_root",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
+            "offset": [
+              -21,
+              3.5,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
+            "offset": [
+              -21,
+              -3.5,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "Bone_root",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_1.pfx",
+            "offset": [
+              21,
+              3.5,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "bone_root",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_2_4_2.pfx",
+            "offset": [
+              21,
+              -3.5,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "Bone_root",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -21,
+              3.5,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -21,
+              -3.5,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "Bone_root",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              21,
+              3.5,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              21,
+              -3.5,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle07",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle07",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle05",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle05",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle03",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle03",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle01",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              -4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "socket_nozzle01",
+            "filename": "/pa/effects/specs/dot_1.pfx",
+            "offset": [
+              4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle07",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
+            "offset": [
+              -4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle07",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_4.pfx",
+            "offset": [
+              4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle05",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
+            "offset": [
+              -4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle05",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_3.pfx",
+            "offset": [
+              4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle03",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
+            "offset": [
+              -4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle03",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_2.pfx",
+            "offset": [
+              4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle01",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
+            "offset": [
+              -4,
+              0.8,
+              0.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "build",
+            "bone": "socket_nozzle01",
+            "filename": "/pa/units/land/vehicle_factory_adv/light_build_bone_1.pfx",
+            "offset": [
+              4,
+              0.8,
+              0.6
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "target": "pa/units/orbital/deep_space_radar/deep_space_radar.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door01",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+            "offset": [
+              4.3,
+              0,
+              2.0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door01",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+            "offset": [
+              8.6,
+              0,
+              2.0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door01",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+            "offset": [
+              10.9,
+              0,
+              1.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door02",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+            "offset": [
+              4.3,
+              0,
+              2.0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door02",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+            "offset": [
+              8.6,
+              0,
+              2.0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door02",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+            "offset": [
+              10.9,
+              0,
+              1.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door03",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+            "offset": [
+              4.3,
+              0,
+              2.0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door03",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+            "offset": [
+              8.6,
+              0,
+              2.0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door03",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+            "offset": [
+              10.9,
+              0,
+              1.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door04",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+            "offset": [
+              4.3,
+              0,
+              2.0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door04",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+            "offset": [
+              8.6,
+              0,
+              2.0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door04",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+            "offset": [
+              10.9,
+              0,
+              1.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door04",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+            "offset": [
+              10.9,
+              0,
+              1.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door04",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+            "offset": [
+              8.6,
+              0,
+              2.0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door04",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+            "offset": [
+              4.3,
+              0,
+              2.0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door03",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+            "offset": [
+              10.9,
+              0,
+              1.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door03",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+            "offset": [
+              8.6,
+              0,
+              2.0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door03",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+            "offset": [
+              4.3,
+              0,
+              2.0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door02",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+            "offset": [
+              10.9,
+              0,
+              1.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door02",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+            "offset": [
+              8.6,
+              0,
+              2.0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door02",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+            "offset": [
+              4.3,
+              0,
+              2.0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door01",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_2.pfx",
+            "offset": [
+              10.9,
+              0,
+              1.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door01",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_1.pfx",
+            "offset": [
+              8.6,
+              0,
+              2.0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_door01",
+            "filename": "/pa/units/orbital/deep_space_radar/light_strobe1_0.pfx",
+            "offset": [
+              4.3,
+              0,
+              2.0
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "target": "pa/units/orbital/delta_v_engine/delta_v_engine.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Big Antenna 1",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+            "offset": [
+              19.16,
+              19.9,
+              20.15
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Little Antenna 1",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+            "offset": [
+              19.9,
+              19.16,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Big Antenna 2",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+            "offset": [
+              19.16,
+              -19.9,
+              20.15
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Little Antenna 2",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+            "offset": [
+              19.9,
+              -19.16,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Big Antenna 3",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+            "offset": [
+              -19.9,
+              -19.16,
+              20.15
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Little Antenna 3",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+            "offset": [
+              -19.16,
+              -19.9,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Big Antenna 4",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+            "offset": [
+              -19.9,
+              19.16,
+              20.15
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Little Antenna 4",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+            "offset": [
+              -19.16,
+              19.9,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Upper Door 1",
+            "type": "build",
+            "bone": "bone_door01",
+            "filename": "/pa/effects/specs/light_2_4_1_4.pfx",
+            "offset": [
+              9,
+              0,
+              2
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Upper Door 2",
+            "type": "build",
+            "bone": "bone_door02",
+            "filename": "/pa/effects/specs/light_2_4_2_4.pfx",
+            "offset": [
+              9,
+              0,
+              2
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Upper Door 3",
+            "type": "build",
+            "bone": "bone_door03",
+            "filename": "/pa/effects/specs/light_2_4_3_4.pfx",
+            "offset": [
+              9,
+              0,
+              2
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Upper Door 4",
+            "type": "build",
+            "bone": "bone_door04",
+            "filename": "/pa/effects/specs/light_2_4_4_4.pfx",
+            "offset": [
+              9,
+              0,
+              2
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Upper Cross 1",
+            "type": "idle",
+            "bone": "bone_cross01",
+            "filename": "/pa/effects/specs/light_1_4_4_2.pfx",
+            "offset": [
+              14.25,
+              0,
+              1.75
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Upper Cross 2",
+            "type": "idle",
+            "bone": "bone_cross02",
+            "filename": "/pa/effects/specs/light_1_4_3_2.pfx",
+            "offset": [
+              14.25,
+              0,
+              1.75
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Upper Cross 3",
+            "type": "idle",
+            "bone": "bone_cross03",
+            "filename": "/pa/effects/specs/light_1_4_2_2.pfx",
+            "offset": [
+              14.25,
+              0,
+              1.75
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Upper Cross 4",
+            "type": "idle",
+            "bone": "bone_cross04",
+            "filename": "/pa/effects/specs/light_1_4_1_2.pfx",
+            "offset": [
+              14.25,
+              0,
+              1.75
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Upper Cross 4",
+            "type": "idle",
+            "bone": "bone_cross04",
+            "filename": "/pa/effects/specs/light_1_4_1_2.pfx",
+            "offset": [
+              14.25,
+              0,
+              1.75
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Upper Cross 3",
+            "type": "idle",
+            "bone": "bone_cross03",
+            "filename": "/pa/effects/specs/light_1_4_2_2.pfx",
+            "offset": [
+              14.25,
+              0,
+              1.75
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Upper Cross 2",
+            "type": "idle",
+            "bone": "bone_cross02",
+            "filename": "/pa/effects/specs/light_1_4_3_2.pfx",
+            "offset": [
+              14.25,
+              0,
+              1.75
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Upper Cross 1",
+            "type": "idle",
+            "bone": "bone_cross01",
+            "filename": "/pa/effects/specs/light_1_4_4_2.pfx",
+            "offset": [
+              14.25,
+              0,
+              1.75
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Upper Door 4",
+            "type": "build",
+            "bone": "bone_door04",
+            "filename": "/pa/effects/specs/light_2_4_4_4.pfx",
+            "offset": [
+              9,
+              0,
+              2
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Upper Door 3",
+            "type": "build",
+            "bone": "bone_door03",
+            "filename": "/pa/effects/specs/light_2_4_3_4.pfx",
+            "offset": [
+              9,
+              0,
+              2
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Upper Door 2",
+            "type": "build",
+            "bone": "bone_door02",
+            "filename": "/pa/effects/specs/light_2_4_2_4.pfx",
+            "offset": [
+              9,
+              0,
+              2
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Upper Door 1",
+            "type": "build",
+            "bone": "bone_door01",
+            "filename": "/pa/effects/specs/light_2_4_1_4.pfx",
+            "offset": [
+              9,
+              0,
+              2
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Little Antenna 4",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+            "offset": [
+              -19.16,
+              19.9,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Big Antenna 4",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+            "offset": [
+              -19.9,
+              19.16,
+              20.15
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Little Antenna 3",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+            "offset": [
+              -19.16,
+              -19.9,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Big Antenna 3",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+            "offset": [
+              -19.9,
+              -19.16,
+              20.15
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Little Antenna 2",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+            "offset": [
+              19.9,
+              -19.16,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Big Antenna 2",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+            "offset": [
+              19.16,
+              -19.9,
+              20.15
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Little Antenna 1",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+            "offset": [
+              19.9,
+              19.16,
+              18.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Big Antenna 1",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+            "offset": [
+              19.16,
+              19.9,
+              20.15
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "target": "pa/units/orbital/mining_platform/mining_platform.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Energy Plant Light 1",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_2_2.pfx",
+            "offset": [
+              0,
+              -7.9,
+              26.8
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Energy Plant Light 2",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_3_2.pfx",
+            "offset": [
+              -7.9,
+              0,
+              26.8
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Energy Plant Light 3",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_1_2.pfx",
+            "offset": [
+              7.9,
+              0,
+              26.8
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Border Light S1-E1",
+            "type": "idle",
+            "bone": "bone_shield01",
+            "filename": "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
+            "offset": [
+              -21.95,
+              5.1,
+              5.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Border Light S1-E4",
+            "type": "idle",
+            "bone": "bone_shield01",
+            "filename": "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
+            "offset": [
+              21.95,
+              5.1,
+              5.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Border Light S2-E2",
+            "type": "idle",
+            "bone": "bone_shield02",
+            "filename": "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
+            "offset": [
+              -21.95,
+              5.1,
+              5.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Border Light S2-E1",
+            "type": "idle",
+            "bone": "bone_shield02",
+            "filename": "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
+            "offset": [
+              21.95,
+              5.1,
+              5.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Border Light S3-E3",
+            "type": "idle",
+            "bone": "bone_shield03",
+            "filename": "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
+            "offset": [
+              -21.95,
+              5.1,
+              5.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Border Light S3-E2",
+            "type": "idle",
+            "bone": "bone_shield03",
+            "filename": "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
+            "offset": [
+              21.95,
+              5.1,
+              5.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Border Light S4-E4",
+            "type": "idle",
+            "bone": "bone_shield04",
+            "filename": "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
+            "offset": [
+              -21.95,
+              5.1,
+              5.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Border Light S4-E3",
+            "type": "idle",
+            "bone": "bone_shield04",
+            "filename": "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
+            "offset": [
+              21.95,
+              5.1,
+              5.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Bottom Antenna",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/orbital/mining_platform/straw_2_8_8.pfx",
+            "offset": [
+              0.5,
+              0.5,
+              -53.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Straw 7",
+            "type": "idle",
+            "bone": "bone_hose01",
+            "filename": "/pa/units/orbital/mining_platform/straw_2_8_7.pfx",
+            "offset": [
+              0,
+              -5.2,
+              -3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Straw 6",
+            "type": "idle",
+            "bone": "bone_hose02",
+            "filename": "/pa/units/orbital/mining_platform/straw_2_8_6.pfx",
+            "offset": [
+              0,
+              -11,
+              -2
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Straw 5",
+            "type": "idle",
+            "bone": "bone_hose03",
+            "filename": "/pa/units/orbital/mining_platform/straw_2_8_5.pfx",
+            "offset": [
+              0,
+              -4,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Straw 4",
+            "type": "idle",
+            "bone": "bone_hose04",
+            "filename": "/pa/units/orbital/mining_platform/straw_2_8_4.pfx",
+            "offset": [
+              0,
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Straw 3",
+            "type": "idle",
+            "bone": "bone_hose05",
+            "filename": "/pa/units/orbital/mining_platform/straw_2_8_3.pfx",
+            "offset": [
+              0,
+              -3,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Straw 2",
+            "type": "idle",
+            "bone": "bone_hose06",
+            "filename": "/pa/units/orbital/mining_platform/straw_2_8_2.pfx",
+            "offset": [
+              0,
+              -8,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Straw 1",
+            "type": "idle",
+            "bone": "bone_hose07",
+            "filename": "/pa/units/orbital/mining_platform/straw_2_8_1.pfx",
+            "offset": [
+              0,
+              -2,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Straw 1",
+            "type": "idle",
+            "bone": "bone_hose07",
+            "filename": "/pa/units/orbital/mining_platform/straw_2_8_1.pfx",
+            "offset": [
+              0,
+              -2,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Straw 2",
+            "type": "idle",
+            "bone": "bone_hose06",
+            "filename": "/pa/units/orbital/mining_platform/straw_2_8_2.pfx",
+            "offset": [
+              0,
+              -8,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Straw 3",
+            "type": "idle",
+            "bone": "bone_hose05",
+            "filename": "/pa/units/orbital/mining_platform/straw_2_8_3.pfx",
+            "offset": [
+              0,
+              -3,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Straw 4",
+            "type": "idle",
+            "bone": "bone_hose04",
+            "filename": "/pa/units/orbital/mining_platform/straw_2_8_4.pfx",
+            "offset": [
+              0,
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Straw 5",
+            "type": "idle",
+            "bone": "bone_hose03",
+            "filename": "/pa/units/orbital/mining_platform/straw_2_8_5.pfx",
+            "offset": [
+              0,
+              -4,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Straw 6",
+            "type": "idle",
+            "bone": "bone_hose02",
+            "filename": "/pa/units/orbital/mining_platform/straw_2_8_6.pfx",
+            "offset": [
+              0,
+              -11,
+              -2
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Straw 7",
+            "type": "idle",
+            "bone": "bone_hose01",
+            "filename": "/pa/units/orbital/mining_platform/straw_2_8_7.pfx",
+            "offset": [
+              0,
+              -5.2,
+              -3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Bottom Antenna",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/orbital/mining_platform/straw_2_8_8.pfx",
+            "offset": [
+              0.5,
+              0.5,
+              -53.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Border Light S4-E3",
+            "type": "idle",
+            "bone": "bone_shield04",
+            "filename": "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
+            "offset": [
+              21.95,
+              5.1,
+              5.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Border Light S4-E4",
+            "type": "idle",
+            "bone": "bone_shield04",
+            "filename": "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
+            "offset": [
+              -21.95,
+              5.1,
+              5.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Border Light S3-E2",
+            "type": "idle",
+            "bone": "bone_shield03",
+            "filename": "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
+            "offset": [
+              21.95,
+              5.1,
+              5.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Border Light S3-E3",
+            "type": "idle",
+            "bone": "bone_shield03",
+            "filename": "/pa/units/orbital/mining_platform/position_light_1_4_3_8.pfx",
+            "offset": [
+              -21.95,
+              5.1,
+              5.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Border Light S2-E1",
+            "type": "idle",
+            "bone": "bone_shield02",
+            "filename": "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
+            "offset": [
+              21.95,
+              5.1,
+              5.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Border Light S2-E2",
+            "type": "idle",
+            "bone": "bone_shield02",
+            "filename": "/pa/units/orbital/mining_platform/position_light_1_4_2_8.pfx",
+            "offset": [
+              -21.95,
+              5.1,
+              5.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Border Light S1-E4",
+            "type": "idle",
+            "bone": "bone_shield01",
+            "filename": "/pa/units/orbital/mining_platform/position_light_1_4_4_8.pfx",
+            "offset": [
+              21.95,
+              5.1,
+              5.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Border Light S1-E1",
+            "type": "idle",
+            "bone": "bone_shield01",
+            "filename": "/pa/units/orbital/mining_platform/position_light_1_4_1_8.pfx",
+            "offset": [
+              -21.95,
+              5.1,
+              5.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Energy Plant Light 3",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_1_2.pfx",
+            "offset": [
+              7.9,
+              0,
+              26.8
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Energy Plant Light 2",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_3_2.pfx",
+            "offset": [
+              -7.9,
+              0,
+              26.8
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Energy Plant Light 1",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/orbital/mining_platform/energy_light_2_4_2_2.pfx",
+            "offset": [
+              0,
+              -7.9,
+              26.8
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "target": "pa/units/orbital/orbital_fabrication_bot/orbital_fabrication_bot.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_leftSolarPanel",
+            "filename": "/pa/effects/specs/lightblink_2_2_1.pfx",
+            "offset": [
+              12.2,
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_rightSolarPanel",
+            "filename": "/pa/effects/specs/lightblink_2_2_2.pfx",
+            "offset": [
+              12,
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_rightSolarPanel",
+            "filename": "/pa/effects/specs/lightblink_2_2_2.pfx",
+            "offset": [
+              12,
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "type": "idle",
+            "bone": "bone_leftSolarPanel",
+            "filename": "/pa/effects/specs/lightblink_2_2_1.pfx",
+            "offset": [
+              12.2,
+              0,
+              0
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "target": "pa/units/orbital/orbital_factory/orbital_factory.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Corner Antenna 1",
+            "type": "idle",
+            "bone": "bone_frontArms",
+            "filename": "/pa/effects/specs/light_1_4_3_4.pfx",
+            "offset": [
+              19.2,
+              -38,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Corner Antenna 2",
+            "type": "idle",
+            "bone": "bone_backArms",
+            "filename": "/pa/effects/specs/light_1_4_1_4.pfx",
+            "offset": [
+              19.2,
+              -38,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Corner Antenna 3",
+            "type": "idle",
+            "bone": "bone_backArms",
+            "filename": "/pa/effects/specs/light_1_4_2_4.pfx",
+            "offset": [
+              -19.2,
+              -38,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Corner Antenna 4",
+            "type": "idle",
+            "bone": "bone_frontArms",
+            "filename": "/pa/effects/specs/light_1_4_4_4.pfx",
+            "offset": [
+              -19.2,
+              -38,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Building Antennas",
+            "type": "build",
+            "bone": "bone_root",
+            "filename": "/pa/units/orbital/orbital_factory/orbital_factory_build_light.pfx"
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Bottom Tri Antenna Light",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/orbital/orbital_factory/orbital_factory_bottom_light.pfx"
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Bottom Tri Antenna Light",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/units/orbital/orbital_factory/orbital_factory_bottom_light.pfx"
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Building Antennas",
+            "type": "build",
+            "bone": "bone_root",
+            "filename": "/pa/units/orbital/orbital_factory/orbital_factory_build_light.pfx"
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Corner Antenna 4",
+            "type": "idle",
+            "bone": "bone_frontArms",
+            "filename": "/pa/effects/specs/light_1_4_4_4.pfx",
+            "offset": [
+              -19.2,
+              -38,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Corner Antenna 3",
+            "type": "idle",
+            "bone": "bone_backArms",
+            "filename": "/pa/effects/specs/light_1_4_2_4.pfx",
+            "offset": [
+              -19.2,
+              -38,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Corner Antenna 2",
+            "type": "idle",
+            "bone": "bone_backArms",
+            "filename": "/pa/effects/specs/light_1_4_1_4.pfx",
+            "offset": [
+              19.2,
+              -38,
+              0
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Corner Antenna 1",
+            "type": "idle",
+            "bone": "bone_frontArms",
+            "filename": "/pa/effects/specs/light_1_4_3_4.pfx",
+            "offset": [
+              19.2,
+              -38,
+              0
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "target": "pa/units/orbital/orbital_fighter/orbital_fighter.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Antenna",
+            "type": "build",
+            "bone": "bone_body",
+            "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+            "offset": [
+              0,
+              0.15,
+              3.9
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Left Wing",
+            "type": "idle",
+            "bone": "bone_wingTip",
+            "filename": "/pa/effects/specs/light_2_4_3_2.pfx",
+            "offset": [
+              -0.9,
+              3.2,
+              -2.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Left Wing - Moving",
+            "type": "moving",
+            "bone": "bone_wingTip",
+            "filename": "/pa/effects/specs/light_2_4_4_2.pfx",
+            "offset": [
+              -0.9,
+              3.2,
+              -2.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Solar Wing",
+            "type": "idle",
+            "bone": "bone_solarPanel",
+            "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+            "offset": [
+              -0.3,
+              -8.5,
+              -1.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Solar Wing - Moving",
+            "type": "moving",
+            "bone": "bone_solarPanel",
+            "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+            "offset": [
+              -0.3,
+              -8.5,
+              -1.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Solar Wing - Moving",
+            "type": "moving",
+            "bone": "bone_solarPanel",
+            "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+            "offset": [
+              -0.3,
+              -8.5,
+              -1.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Solar Wing",
+            "type": "idle",
+            "bone": "bone_solarPanel",
+            "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+            "offset": [
+              -0.3,
+              -8.5,
+              -1.3
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Left Wing - Moving",
+            "type": "moving",
+            "bone": "bone_wingTip",
+            "filename": "/pa/effects/specs/light_2_4_4_2.pfx",
+            "offset": [
+              -0.9,
+              3.2,
+              -2.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Left Wing",
+            "type": "idle",
+            "bone": "bone_wingTip",
+            "filename": "/pa/effects/specs/light_2_4_3_2.pfx",
+            "offset": [
+              -0.9,
+              3.2,
+              -2.6
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Antenna",
+            "type": "build",
+            "bone": "bone_body",
+            "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+            "offset": [
+              0,
+              0.15,
+              3.9
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "target": "pa/units/orbital/orbital_laser/orbital_laser.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets",
+          "value": [
+            {
+              "type": "idle",
+              "bone": "bone_rotator",
+              "filename": "/pa/effects/specs/light_2_4_1.pfx",
+              "offset": [
+                8.45,
+                1,
+                -3.5
+              ]
+            },
+            {
+              "type": "idle",
+              "bone": "bone_rotator",
+              "filename": "/pa/effects/specs/light_2_4_1.pfx",
+              "offset": [
+                -8.45,
+                -1,
+                -3.5
+              ]
+            },
+            {
+              "type": "idle",
+              "bone": "bone_rotator",
+              "filename": "/pa/effects/specs/lightblink_1_4_1.pfx",
+              "offset": [
+                7.6,
+                1,
+                -1.3
+              ]
+            },
+            {
+              "type": "idle",
+              "bone": "bone_rotator",
+              "filename": "/pa/effects/specs/lightblink_1_4_1.pfx",
+              "offset": [
+                -7.6,
+                -1,
+                -1.3
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "pa/units/orbital/orbital_launcher/orbital_launcher.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Big Antenna",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+            "offset": [
+              -5,
+              9.66,
+              66.83
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Little Antenna",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+            "offset": [
+              -5,
+              10.85,
+              64.33
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Ramp 3",
+            "type": "build",
+            "bone": "bone_root",
+            "filename": "/pa/units/orbital/orbital_launcher/light_build.pfx",
+            "offset": [
+              23.5,
+              -1.15,
+              4.8
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Ramp 3",
+            "type": "build",
+            "bone": "bone_root",
+            "filename": "/pa/units/orbital/orbital_launcher/light_build.pfx",
+            "offset": [
+              23.5,
+              -1.15,
+              4.8
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Little Antenna",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+            "offset": [
+              -5,
+              10.85,
+              64.33
+            ]
+          }
+        },
+        {
+          "op": "add",
+          "path": "/fx_offsets/-",
+          "value": {
+            "label": "Big Antenna",
+            "type": "idle",
+            "bone": "bone_root",
+            "filename": "/pa/effects/specs/light_2_4_2_2.pfx",
+            "offset": [
+              -5,
+              9.66,
+              66.83
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "target": "pa/units/orbital/solar_array/solar_array.json",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/fx_offsets",
+          "value": [
+            {
+              "type": "idle",
+              "bone": "bone_body",
+              "filename": "/pa/effects/specs/light_2_4_1.pfx",
+              "offset": [
+                0,
+                -12.5,
+                0
+              ]
+            },
+            {
+              "type": "idle",
+              "bone": "bone_body",
+              "filename": "/pa/effects/specs/light_2_4_1_4.pfx",
+              "offset": [
+                0.5,
+                -10,
+                0
+              ]
+            },
+            {
+              "type": "idle",
+              "bone": "bone_body",
+              "filename": "/pa/effects/specs/light_2_4_1_2.pfx",
+              "offset": [
+                -0.5,
+                -11.2,
+                0
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/update.py
+++ b/update.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+"""
+Run this file when you want to regen all the effects for a new build
+
+NOTE: as you can see, it relies on my pa_tools library to be up one directory and inside pa_tools
+You can either download my repo to the parent of this mod's dir, or you can download it somewhere else and just update this path
+"""
+
+import sys
+sys.path.append("../pa_tools")
+
+import mod_generator
+
+mod_generator.run("pa_fx_gen.json")


### PR DESCRIPTION
Two things to note about this addition:
1) You don't need to update any unit.json files yourself any more.
2) When there is a new build, all you need to do is run ./update.py with python3
       - running update will make a new modinfo.json file to indicate the the proper build number and date
       - if you want the version number to be updated, edit the pa_fx_gen.json file. You should see a key for the modinfo file that is the version number.
       - the update script also applies all the fx_offsets elements to the new PA base files.
